### PR TITLE
 Update instructions for use with a central Jenkinsfile 

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -29,8 +29,8 @@ Parameter:
 * GRETL_JOB_REPO_URL: Repo containing the GRETL jobs.
 * GRETL_JOB_FILE_PATH: Base path to the GRETL job definitions (the Gradle build script) (Ant style).
 * GRETL_JOB_FILE_NAME: Name of the GRETL job file (the Gradle build script).
-* JENKINS_HOSTNAME: The public hostname for the Jenkins service.
 * VOLUME_CAPACITY: Persistent volume size for Jenkins configuration data, e.g. 512Mi, 2Gi.
+* JENKINS_HOSTNAME: The public hostname for the Jenkins service.
 
 ### GRETL runtime
 The GRETL runtime configuration with definition of which Docker image to pull from Docker Hub.

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -18,7 +18,7 @@ oc process -f openshift/templates/jenkins-s2i-persistent-template.yaml \
   -p JENKINS_IMAGE_STREAM_TAG="jenkins:2" \
   -p GRETL_JOB_REPO_URL="git://github.com/sogis/gretljobs.git" \
   -p GRETL_JOB_FILE_PATH="**" \
-  -p GRETL_JOB_FILE_NAME="gretl-job.groovy" \
+  -p GRETL_JOB_FILE_NAME="build.gradle" \
   -p VOLUME_CAPACITY="2Gi" \
   -p JENKINS_HOSTNAME="gretl.example.org" \
   | oc apply -f -
@@ -27,8 +27,8 @@ Parameter:
 * JENKINS_CONFIGURATION_REPO_URL: Repo containing the Jenkins configuration.
 * JENKINS_IMAGE_STREAM_TAG: Docker base image for the Jenkins. 
 * GRETL_JOB_REPO_URL: Repo containing the GRETL jobs.
-* GRETL_JOB_FILE_PATH: Base path to the GRETL job definitions (Ant style)
-* GRETL_JOB_FILE_NAME: Name of the GRETL job configuration file.
+* GRETL_JOB_FILE_PATH: Base path to the GRETL job definitions (the Gradle build script) (Ant style).
+* GRETL_JOB_FILE_NAME: Name of the GRETL job file (the Gradle build script).
 * JENKINS_HOSTNAME: The public hostname for the Jenkins service.
 * VOLUME_CAPACITY: Persistent volume size for Jenkins configuration data, e.g. 512Mi, 2Gi.
 

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -13,7 +13,7 @@ oc new-project gretl-system
 ### GRETL-Jenkins
 Apply project template with the GRETL-Jenkins configuration.
 ```
-oc process -f serviceConfig/templates/jenkins-s2i-persistent-template.yaml \
+oc process -f openshift/templates/jenkins-s2i-persistent-template.yaml \
   -p JENKINS_CONFIGURATION_REPO_URL="https://github.com/sogis/openshift-jenkins.git" \
   -p JENKINS_IMAGE_STREAM_TAG="jenkins:2" \
   -p GRETL_JOB_REPO_URL="git://github.com/sogis/gretljobs.git" \
@@ -37,7 +37,7 @@ The GRETL runtime configuration with definition of which Docker image to pull fr
 
 Add gretl imagestream to pull newest GRETL runtime image:
 ```
-oc process -f serviceConfig/templates/gretl-is-template.yaml \
+oc process -f openshift/templates/gretl-is-template.yaml \
   -p GRETL_RUNTIME_IMAGE="sogis/gretl-runtime:32" \
   | oc apply -f -
 ```
@@ -47,7 +47,7 @@ Parameter:
 If you need to configure more details of the GRETL pod, then apply the following 
 ConfigMap:
 ```
-oc apply -f serviceConfig/templates/gretl-pod-template-configmap.yaml
+oc apply -f openshift/templates/gretl-pod-template-configmap.yaml
 ```
 After the creation of the *gretl* ConfigMap, update the image URI field (`<image/>`) of 
 the ConfigMap manually with the information returned by the command 


### PR DESCRIPTION
The changes describe how to create the GRETL system ("GRETL-Jenkins") which now uses one single, central Jenkinsfile for all GRETL Jobs rather than one Jenkinsfile (used to be called _gretl-job.groovy_ until now) per GRETL Job.

Plus contains some fixes of the documentation.