### PR TITLE
OpenShift: resource limits and volume for /tmp

### DIFF
--- a/openshift/templates/gretl-ili2pg4-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-ili2pg4-pod-template-configmap.yaml
@@ -17,6 +17,12 @@ data:
       <nodeSelector></nodeSelector>
       <volumes>
         <org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
+          <mountPath>/tmp</mountPath>
+          <!-- Attention: Before creating this ConfigMap, please adapt the persistent volume claim name below so it points to the right PVC -->
+          <claimName>agi-gretl-test-lowback</claimName>
+          <readOnly>false</readOnly>
+        </org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
+        <org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
           <mountPath>/opt/gretl-jenkins-share</mountPath>
           <claimName>jenkins-share</claimName>
           <readOnly>false</readOnly>
@@ -29,7 +35,7 @@ data:
           <image>docker-registry.default.svc:5000/PROJECT-NAME/gretl:ili2pg4</image>
           <privileged>false</privileged>
           <alwaysPullImage>true</alwaysPullImage>
-          <workingDir>/tmp</workingDir>
+          <workingDir>/workspace</workingDir>
           <command></command>
           <args>${computer.jnlpmac} ${computer.name}</args>
           <ttyEnabled>false</ttyEnabled>

--- a/openshift/templates/gretl-ili2pg4-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-ili2pg4-pod-template-configmap.yaml
@@ -19,7 +19,7 @@ data:
         <org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
           <mountPath>/tmp</mountPath>
           <!-- Attention: Before creating this ConfigMap, please adapt the persistent volume claim name below so it points to the right PVC -->
-          <claimName>agi-gretl-test-lowback</claimName>
+          <claimName>agi-gretl-ENVIRONMENT-lowback</claimName>
           <readOnly>false</readOnly>
         </org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
         <org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>

--- a/openshift/templates/gretl-ili2pg4-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-ili2pg4-pod-template-configmap.yaml
@@ -33,10 +33,10 @@ data:
           <command></command>
           <args>${computer.jnlpmac} ${computer.name}</args>
           <ttyEnabled>false</ttyEnabled>
-          <resourceRequestCpu></resourceRequestCpu>
-          <resourceRequestMemory></resourceRequestMemory>
-          <resourceLimitCpu></resourceLimitCpu>
-          <resourceLimitMemory></resourceLimitMemory>
+          <resourceRequestCpu>200m</resourceRequestCpu>
+          <resourceRequestMemory>1Gi</resourceRequestMemory>
+          <resourceLimitCpu>1</resourceLimitCpu>
+          <resourceLimitMemory>2.5Gi</resourceLimitMemory>
           <envVars/>
         </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
       </containers>

--- a/openshift/templates/gretl-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-pod-template-configmap.yaml
@@ -15,7 +15,7 @@ data:
       <label>gretl</label>
       <serviceAccount>jenkins</serviceAccount>
       <nodeSelector></nodeSelector>
-       <volumes>
+      <volumes>
         <org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
           <mountPath>/tmp</mountPath>
           <!-- Attention: Before creating this ConfigMap, please adapt the persistent volume claim name below so it points to the right PVC -->

--- a/openshift/templates/gretl-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-pod-template-configmap.yaml
@@ -19,7 +19,7 @@ data:
         <org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
           <mountPath>/tmp</mountPath>
           <!-- Attention: Before creating this ConfigMap, please adapt the persistent volume claim name below so it points to the right PVC -->
-          <claimName>agi-gretl-test-lowback</claimName>
+          <claimName>agi-gretl-ENVIRONMENT-lowback</claimName>
           <readOnly>false</readOnly>
         </org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
         <org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>

--- a/openshift/templates/gretl-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-pod-template-configmap.yaml
@@ -33,10 +33,10 @@ data:
           <command></command>
           <args>${computer.jnlpmac} ${computer.name}</args>
           <ttyEnabled>false</ttyEnabled>
-          <resourceRequestCpu></resourceRequestCpu>
-          <resourceRequestMemory></resourceRequestMemory>
-          <resourceLimitCpu></resourceLimitCpu>
-          <resourceLimitMemory></resourceLimitMemory>
+          <resourceRequestCpu>200m</resourceRequestCpu>
+          <resourceRequestMemory>1Gi</resourceRequestMemory>
+          <resourceLimitCpu>1</resourceLimitCpu>
+          <resourceLimitMemory>2.5Gi</resourceLimitMemory>
           <envVars/>
         </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
       </containers>

--- a/openshift/templates/gretl-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-pod-template-configmap.yaml
@@ -15,7 +15,13 @@ data:
       <label>gretl</label>
       <serviceAccount>jenkins</serviceAccount>
       <nodeSelector></nodeSelector>
-      <volumes>
+       <volumes>
+        <org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
+          <mountPath>/tmp</mountPath>
+          <!-- Attention: Before creating this ConfigMap, please adapt the persistent volume claim name below so it points to the right PVC -->
+          <claimName>agi-gretl-test-lowback</claimName>
+          <readOnly>false</readOnly>
+        </org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
         <org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
           <mountPath>/opt/gretl-jenkins-share</mountPath>
           <claimName>jenkins-share</claimName>
@@ -29,7 +35,7 @@ data:
           <image>docker-registry.default.svc:5000/PROJECT-NAME/gretl:latest</image>
           <privileged>false</privileged>
           <alwaysPullImage>true</alwaysPullImage>
-          <workingDir>/tmp</workingDir>
+          <workingDir>/workspace</workingDir>
           <command></command>
           <args>${computer.jnlpmac} ${computer.name}</args>
           <ttyEnabled>false</ttyEnabled>

--- a/openshift/templates/jenkins-s2i-persistent-template.yaml
+++ b/openshift/templates/jenkins-s2i-persistent-template.yaml
@@ -146,7 +146,11 @@ objects:
             timeoutSeconds: 240
           resources:
             limits:
+              cpu: ${CPU_LIMIT}
               memory: ${MEMORY_LIMIT}
+            requests:
+              cpu: ${CPU_REQUEST}
+              memory: ${MEMORY_REQUEST}
           securityContext:
             capabilities: {}
             privileged: false
@@ -236,10 +240,22 @@ parameters:
   displayName: Enable OAuth in Jenkins
   name: ENABLE_OAUTH
   value: "true"
+- description: The minimum amount of CPU the container is guaranteed.
+  displayName: CPU Request
+  name: CPU_REQUEST
+  value: 100m
+- description: The maximum amount of CPU the container is allowed to use when running.
+  displayName: CPU Limit
+  name: CPU_LIMIT
+  value: "1"
+- description: The minimum amount of memory the container is guaranteed.
+  displayName: Memory Request
+  name: MEMORY_REQUEST
+  value: 1.2Gi
 - description: Maximum amount of memory the container can use.
   displayName: Memory Limit
   name: MEMORY_LIMIT
-  value: 512Mi
+  value: 2Gi
 - description: Volume space available for data, e.g. 512Mi, 2Gi.
   displayName: Volume Capacity
   name: VOLUME_CAPACITY


### PR DESCRIPTION
* Set resource limits for Jenkins and GRETL
* GRETL agent: Mount a volume for /tmp; and use /workspace as working dir instead of /tmp