### PR TITLE
Do Jenkins s2i build with image from Docker Hub

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -15,7 +15,7 @@ Apply project template with the GRETL-Jenkins configuration.
 ```
 oc process -f openshift/templates/jenkins-s2i-persistent-template.yaml \
   -p JENKINS_CONFIGURATION_REPO_URL="https://github.com/sogis/openshift-jenkins.git" \
-  -p JENKINS_IMAGE_STREAM_TAG="jenkins:2" \
+  -p JENKINS_DOCKER_IMAGE_TAG="v3.11" \
   -p GRETL_JOB_REPO_URL="https://github.com/sogis/gretljobs.git" \
   -p GRETL_JOB_FILE_PATH="**" \
   -p GRETL_JOB_FILE_NAME="build.gradle" \
@@ -25,7 +25,7 @@ oc process -f openshift/templates/jenkins-s2i-persistent-template.yaml \
 ```
 Parameter:
 * JENKINS_CONFIGURATION_REPO_URL: Repo containing the Jenkins configuration.
-* JENKINS_IMAGE_STREAM_TAG: Docker base image for the Jenkins. 
+* JENKINS_DOCKER_IMAGE_TAG: Jenkins base image tag to be used.
 * GRETL_JOB_REPO_URL: Repo containing the GRETL jobs.
 * GRETL_JOB_FILE_PATH: Base path to the GRETL job definitions (Ant style)
 * GRETL_JOB_FILE_NAME: Name of the GRETL job script file (usually build.gradle).

--- a/openshift/templates/jenkins-s2i-persistent-template.yaml
+++ b/openshift/templates/jenkins-s2i-persistent-template.yaml
@@ -73,9 +73,8 @@ objects:
     strategy:
       sourceStrategy:
         from:
-          kind: ImageStreamTag
-          name: ${JENKINS_IMAGE_STREAM_TAG}
-          namespace: ${NAMESPACE}
+          kind: DockerImage
+          name: openshift/jenkins-2-centos7:${JENKINS_DOCKER_IMAGE_TAG}
       type: Source
     triggers:
     - github:
@@ -265,10 +264,10 @@ parameters:
   displayName: Jenkins ImageStream Namespace
   name: NAMESPACE
   value: openshift
-- description: Name of the ImageStreamTag to be used for the Jenkins image.
-  displayName: Jenkins ImageStreamTag
-  name: JENKINS_IMAGE_STREAM_TAG
-  value: jenkins:2
+- description: Name of the Tag to be used for the Jenkins image.
+  displayName: Jenkins Docker Image Tag
+  name: JENKINS_DOCKER_IMAGE_TAG
+  value: v3.11
 - description: Url of the Git repo holding the Jenkins configuration.
   displayName: Jenkins configuration Git repo
   name: JENKINS_CONFIGURATION_REPO_URL


### PR DESCRIPTION
Instead of using the Jenkins image included in the OpenShift catalog, use an image from Docker Hub as base image for the s2i build for Jenkins. This has the advantage that always the same base image is used, also in Minishift. And we have control over which base image version is used.

Note that this image is based on CentOS rather than RedHat Linux. However this should basically make no difference for us.