### PR TITLE
Undo mount volume for /tmp

### DIFF
--- a/openshift/templates/gretl-ili2pg4-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-ili2pg4-pod-template-configmap.yaml
@@ -17,12 +17,6 @@ data:
       <nodeSelector></nodeSelector>
       <volumes>
         <org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
-          <mountPath>/tmp</mountPath>
-          <!-- Attention: Before creating this ConfigMap, please adapt the persistent volume claim name below so it points to the right PVC -->
-          <claimName>agi-gretl-ENVIRONMENT-lowback</claimName>
-          <readOnly>false</readOnly>
-        </org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
-        <org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
           <mountPath>/opt/gretl-jenkins-share</mountPath>
           <claimName>jenkins-share</claimName>
           <readOnly>false</readOnly>

--- a/openshift/templates/gretl-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-pod-template-configmap.yaml
@@ -17,12 +17,6 @@ data:
       <nodeSelector></nodeSelector>
       <volumes>
         <org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
-          <mountPath>/tmp</mountPath>
-          <!-- Attention: Before creating this ConfigMap, please adapt the persistent volume claim name below so it points to the right PVC -->
-          <claimName>agi-gretl-ENVIRONMENT-lowback</claimName>
-          <readOnly>false</readOnly>
-        </org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
-        <org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
           <mountPath>/opt/gretl-jenkins-share</mountPath>
           <claimName>jenkins-share</claimName>
           <readOnly>false</readOnly>


### PR DESCRIPTION
Don't mount a volume for `/tmp` for all GRETL jobs. Rather mount it only for those jobs that actually require a larger `/tmp`.

(But keep the `workingDir `at `/workspace`. So when mounting a larger `/tmp` is required for a certain GRETL job, this doesn't interfere with the `emptyDir `volume that is created by default for the `workingDir`.)