### PR TITLE
New solution for mounting volume for /tmp

### DIFF
--- a/openshift/templates/gretl-bigtmp-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-bigtmp-pod-template-configmap.yaml
@@ -1,0 +1,65 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: gretl-bigtmp
+  labels:
+    app: gretl-platform
+    role: jenkins-slave
+data:
+  template: |-
+    <org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
+      <inheritFrom></inheritFrom>
+      <name>gretl-bigtmp</name>
+      <instanceCap>2</instanceCap>
+      <idleMinutes>0</idleMinutes>
+      <label>gretl-bigtmp</label>
+      <serviceAccount>jenkins</serviceAccount>
+      <nodeSelector></nodeSelector>
+      <volumes>
+        <org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
+          <mountPath>/tmp</mountPath>
+          <!-- Attention: Before creating this ConfigMap, please adapt the persistent volume claim name below so it points to the right PVC -->
+          <claimName>agi-gretl-ENVIRONMENT-lowback</claimName>
+          <readOnly>false</readOnly>
+        </org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
+        <org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
+          <mountPath>/opt/gretl-jenkins-share</mountPath>
+          <claimName>jenkins-share</claimName>
+          <readOnly>false</readOnly>
+        </org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
+      </volumes>
+      <containers>
+        <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
+          <name>jnlp</name>
+          <!-- Attention: Before creating this ConfigMap, please adapt the image URI below so it points to the right project -->
+          <image>docker-registry.default.svc:5000/PROJECT-NAME/gretl:latest</image>
+          <privileged>false</privileged>
+          <alwaysPullImage>true</alwaysPullImage>
+          <workingDir>/workspace</workingDir>
+          <command></command>
+          <args>${computer.jnlpmac} ${computer.name}</args>
+          <ttyEnabled>false</ttyEnabled>
+          <resourceRequestCpu>200m</resourceRequestCpu>
+          <resourceRequestMemory>1Gi</resourceRequestMemory>
+          <resourceLimitCpu>1</resourceLimitCpu>
+          <resourceLimitMemory>2.5Gi</resourceLimitMemory>
+          <envVars/>
+        </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
+      </containers>
+      <envVars/>
+      <annotations/>
+      <imagePullSecrets/>
+      <nodeProperties/>
+      <yaml>
+    apiVersion: v1
+    kind: Pod
+    spec:
+      containers:
+        - name: jnlp
+          envFrom:
+            - configMapRef:
+                name: gretl-resources
+            - secretRef:
+                name: gretl-secrets
+      </yaml>
+    </org.csanchez.jenkins.plugins.kubernetes.PodTemplate>

--- a/openshift/templates/gretl-ili2pg4-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-ili2pg4-pod-template-configmap.yaml
@@ -17,12 +17,6 @@ data:
       <nodeSelector></nodeSelector>
       <volumes>
         <org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
-          <mountPath>/tmp</mountPath>
-          <!-- Attention: Before creating this ConfigMap, please adapt the persistent volume claim name below so it points to the right PVC -->
-          <claimName>agi-gretl-ENVIRONMENT-lowback</claimName>
-          <readOnly>false</readOnly>
-        </org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
-        <org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
           <mountPath>/opt/gretl-jenkins-share</mountPath>
           <claimName>jenkins-share</claimName>
           <readOnly>false</readOnly>
@@ -35,7 +29,7 @@ data:
           <image>docker-registry.default.svc:5000/PROJECT-NAME/gretl:ili2pg4</image>
           <privileged>false</privileged>
           <alwaysPullImage>true</alwaysPullImage>
-          <workingDir>/workspace</workingDir>
+          <workingDir>/tmp</workingDir>
           <command></command>
           <args>${computer.jnlpmac} ${computer.name}</args>
           <ttyEnabled>false</ttyEnabled>

--- a/openshift/templates/gretl-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-pod-template-configmap.yaml
@@ -17,12 +17,6 @@ data:
       <nodeSelector></nodeSelector>
       <volumes>
         <org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
-          <mountPath>/tmp</mountPath>
-          <!-- Attention: Before creating this ConfigMap, please adapt the persistent volume claim name below so it points to the right PVC -->
-          <claimName>agi-gretl-ENVIRONMENT-lowback</claimName>
-          <readOnly>false</readOnly>
-        </org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
-        <org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
           <mountPath>/opt/gretl-jenkins-share</mountPath>
           <claimName>jenkins-share</claimName>
           <readOnly>false</readOnly>
@@ -35,7 +29,7 @@ data:
           <image>docker-registry.default.svc:5000/PROJECT-NAME/gretl:latest</image>
           <privileged>false</privileged>
           <alwaysPullImage>true</alwaysPullImage>
-          <workingDir>/workspace</workingDir>
+          <workingDir>/tmp</workingDir>
           <command></command>
           <args>${computer.jnlpmac} ${computer.name}</args>
           <ttyEnabled>false</ttyEnabled>


### PR DESCRIPTION
Seit Commit https://github.com/sogis/gretl/commit/22dce739f127dc4876518dee75d6fc39d05cb72a#diff-d9b09998f84fdfa4153d68db67fc33dee0027ff4df4ec93607f357894d92f520 wird immer ein Volume unter `/tmp` gemountet, weil ein bestimmter GRETL-Job ungefähr 32GB RAM benötigte. Allerdings wuchs die Datenmenge auf diesem Volume kontinuierlich an, weil die Jobs in der Regel die Daten unter `/tmp` nicht aufräumen.

Neu soll das Volume deshalb nur noch bei denjenigen Jobs gemountet werden, die das tatsächlich brauchen, und bei diesen Jobs soll besonders darauf geachtet werden, dass sie die Daten unter `/tmp` aufräumen. Deshalb werden die diesbezüglichen Änderungen rückgängig gemacht (Volume nicht mounten, `workingDir` auf `/tmp` zurückstellen). Dafür wird ein zusätzliches Pod Template _gretl-bigtmp_ erstellt, das dann spezifisch für solche Jobs benutzt wird, indem es in der Datei `job.properties` des GRETL-Jobs ausgewählt wird.