### PR TITLE
Set max heap size to 1024m by default

### DIFF
--- a/openshift/templates/gretl-bigtmp-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-bigtmp-pod-template-configmap.yaml
@@ -38,7 +38,12 @@ data:
           <resourceRequestMemory>1Gi</resourceRequestMemory>
           <resourceLimitCpu>1</resourceLimitCpu>
           <resourceLimitMemory>3.5Gi</resourceLimitMemory>
-          <envVars/>
+          <envVars>
+            <org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
+              <key>GRADLE_OPTS</key>
+              <value>-Xmx1024m</value>
+            </org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
+          </envVars>
         </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
       </containers>
       <envVars/>

--- a/openshift/templates/gretl-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-pod-template-configmap.yaml
@@ -30,7 +30,12 @@ data:
           <resourceRequestMemory>1Gi</resourceRequestMemory>
           <resourceLimitCpu>1</resourceLimitCpu>
           <resourceLimitMemory>3.5Gi</resourceLimitMemory>
-          <envVars/>
+          <envVars>
+            <org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
+              <key>GRADLE_OPTS</key>
+              <value>-Xmx1024m</value>
+            </org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
+          </envVars>
         </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
       </containers>
       <envVars/>


### PR DESCRIPTION
If we don't set it, it's being set to 25% of the container memory limit, see https://docs.openshift.com/container-platform/4.7/openshift_images/using_images/images-other-jenkins-agent.html#images-other-jenkins-agent-memory_images-other-jenkins-agent

For further details see sogis/gretljobs/pull/996