### PR TITLE
Simplify image

### DIFF
--- a/runtimeImage/gretl/Dockerfile.local
+++ b/runtimeImage/gretl/Dockerfile.local
@@ -1,6 +1,6 @@
 FROM bellsoft/liberica-openjdk-alpine-musl:8u312-7
 
-CMD ["gradle"]
+CMD ["gretl"]
 
 WORKDIR /home/gradle
 

--- a/runtimeImage/gretl/Dockerfile.local
+++ b/runtimeImage/gretl/Dockerfile.local
@@ -4,6 +4,8 @@ CMD ["gradle"]
 
 WORKDIR /home/gradle
 
+ENV GRADLE_USER_HOME=/home/gradle/.gradle
+
 ENV GRADLE_HOME /opt/gradle
 ENV GRADLE_VERSION 4.2.1
 ARG GRADLE_DOWNLOAD_SHA256=b551cc04f2ca51c78dd14edb060621f0e5439bdfafa6fd167032a09ac708fbc0

--- a/runtimeImage/gretl/Dockerfile.local
+++ b/runtimeImage/gretl/Dockerfile.local
@@ -35,4 +35,6 @@ RUN ls -la /usr/local/bin/  && \
     ls -la /home/gradle && \
     ls -la /home/gradle/libs
 
+WORKDIR /home/gradle/project
+
 USER 1001

--- a/runtimeImage/gretl/Dockerfile.local
+++ b/runtimeImage/gretl/Dockerfile.local
@@ -3,6 +3,23 @@ FROM bellsoft/liberica-openjdk-alpine-musl:8u312-7
 CMD ["gradle"]
 
 ENV GRADLE_HOME /opt/gradle
+ENV GRADLE_VERSION 4.2.1
+ARG GRADLE_DOWNLOAD_SHA256=b551cc04f2ca51c78dd14edb060621f0e5439bdfafa6fd167032a09ac708fbc0
+RUN set -o errexit -o nounset \
+    && echo "Downloading Gradle" \
+    && wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
+    \
+    && echo "Checking download hash" \
+    && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum -c - \
+    \
+    && echo "Installing Gradle" \
+    && unzip gradle.zip \
+    && rm gradle.zip \
+    && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
+    && ln -s "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle \
+    \
+    && echo "Testing Gradle installation" \
+    && gradle --version
 
 RUN set -o errexit -o nounset \
     && echo "Adding gradle user and group" \
@@ -23,24 +40,6 @@ RUN chown -R gradle:gradle /home/gradle \
 VOLUME /home/gradle/.gradle
 
 WORKDIR /home/gradle
-
-ENV GRADLE_VERSION 4.2.1
-ARG GRADLE_DOWNLOAD_SHA256=b551cc04f2ca51c78dd14edb060621f0e5439bdfafa6fd167032a09ac708fbc0
-RUN set -o errexit -o nounset \
-    && echo "Downloading Gradle" \
-    && wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
-    \
-    && echo "Checking download hash" \
-    && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum -c - \
-    \
-    && echo "Installing Gradle" \
-    && unzip gradle.zip \
-    && rm gradle.zip \
-    && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
-    && ln -s "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle \
-    \
-    && echo "Testing Gradle installation" \
-    && gradle --version
 
 RUN mkdir -p /home/default/.gradle \
     && chown -R gradle:root /home/default \

--- a/runtimeImage/gretl/Dockerfile.local
+++ b/runtimeImage/gretl/Dockerfile.local
@@ -21,24 +21,15 @@ RUN set -o errexit -o nounset \
     && echo "Testing Gradle installation" \
     && gradle --version
 
-RUN set -o errexit -o nounset \
-    && echo "Adding gradle user and group" \
-    && addgroup --system --gid 1001 gradle \
-    && adduser --system --ingroup gradle --uid 1001 --shell /bin/ash gradle \
-    && mkdir /home/gradle/.gradle
+RUN mkdir -p /home/gradle/.gradle
 
 COPY gretl /usr/local/bin/
 COPY __jars4image /home/gradle/libs/
-
 COPY init.gradle /home/gradle/
 
-RUN chown -R gradle:gradle /home/gradle
+RUN chmod -R g+w /home/gradle
 
 WORKDIR /home/gradle
-
-RUN mkdir -p /home/default/.gradle \
-    && chown -R gradle:root /home/default \
-    && chmod -R g=u /home/default
 
 RUN ls -la /usr/local/bin/  && \
     ls -la /home/gradle && \

--- a/runtimeImage/gretl/Dockerfile.local
+++ b/runtimeImage/gretl/Dockerfile.local
@@ -32,12 +32,7 @@ COPY __jars4image /home/gradle/libs/
 
 COPY init.gradle /home/gradle/
 
-RUN chown -R gradle:gradle /home/gradle \
-    \
-    && echo "Symlinking root Gradle cache to gradle Gradle cache" \
-    && ln -s /home/gradle/.gradle /root/.gradle
-
-VOLUME /home/gradle/.gradle
+RUN chown -R gradle:gradle /home/gradle
 
 WORKDIR /home/gradle
 

--- a/runtimeImage/gretl/Dockerfile.local
+++ b/runtimeImage/gretl/Dockerfile.local
@@ -2,6 +2,8 @@ FROM bellsoft/liberica-openjdk-alpine-musl:8u312-7
 
 CMD ["gradle"]
 
+WORKDIR /home/gradle
+
 ENV GRADLE_HOME /opt/gradle
 ENV GRADLE_VERSION 4.2.1
 ARG GRADLE_DOWNLOAD_SHA256=b551cc04f2ca51c78dd14edb060621f0e5439bdfafa6fd167032a09ac708fbc0
@@ -21,15 +23,11 @@ RUN set -o errexit -o nounset \
     && echo "Testing Gradle installation" \
     && gradle --version
 
-RUN mkdir -p /home/gradle/.gradle
-
 COPY gretl /usr/local/bin/
 COPY __jars4image /home/gradle/libs/
 COPY init.gradle /home/gradle/
 
 RUN chmod -R g+w /home/gradle
-
-WORKDIR /home/gradle
 
 RUN ls -la /usr/local/bin/  && \
     ls -la /home/gradle && \


### PR DESCRIPTION
Ich habe das Image vereinfacht:
* Das Volume für `/home/gradle/.gradle` fällt weg
* Der Symlink von `/root/.gradle` auf `/home/gradle/.gradle` ist nicht nötig, weil das Image nicht unter _root_ laufen soll
* Es wird kein User _gradle_ angelegt, weil das Image unter einem beliebigen User (User-ID) laufen soll. (Das Original-Gradle-Image funktioniert, wenn man das Gradle-Projekt mountet, gemäss https://github.com/keeganwitt/docker-gradle#how-to-use-this-image nur dann, wenn der lokale User die UID 1000 hat; ansonsten muss man es als _root_ laufen lassen.)

Zudem folgende Erweiterungen:
* Neuer grundsätzlicher Ablauf im Image:
  1. Gradle installieren
  2. GRETL installieren
  3. Berechtigungen auf `/home/gradle` setzen, so dass das Image unter einem beliebigen User laufen kann
* Das Verzeichnis `/home/gradle` wird mit dem Befehl `WORKDIR` implizit angelegt
* Das Verzeichnis `/home/gradle/.gradle` wird automatisch angelegt, wenn am Ende der Gradle-Installation der Testaufruf gemacht wird (`gradle --version`)
* Am Ende wird `WORKDIR` auf `/home/gradle/project` gesetzt; hier mountet man beim Ausführen des Containers das Gradle-Projekt, und so muss man beim Ausführen des Containers nicht auch noch `cd /home/gradle/project` ausführen.
* Neu ist `CMD ["gretl"]` (statt `["gradle"]`); dank diesen beiden letzten Änderungen wird sich voraussichtlich das Wrapper-Skript `start-gretl.sh` erübrigen.