### PR TITLE
Update Jenkins agent

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -3,7 +3,7 @@ OpenShift GRETL system project
 Create the GRETL system on the OpenShift container platform.
 
 
-## Setup runtime with Jenkins
+## Setup the GRETL system with Jenkins
 
 ### Create project
 ```
@@ -39,19 +39,21 @@ Parameter:
 * VOLUME_CAPACITY: Persistent volume size for Jenkins configuration data, e.g. 512Mi, 2Gi.
 * JENKINS_HOSTNAME: The public hostname for the Jenkins service.
 
-### GRETL runtime
-The GRETL runtime configuration with definition of which Docker image to pull from Docker Hub.
+### Jenkins agent
 
-#### Create the gretl image stream providing the GRETL runtime image
+The configuration of the Jenkins agent,
+including the definition of which Docker image to pull from Docker Hub.
 
-Add the *gretl* image stream to pull the newest GRETL runtime image:
+#### Create the gretl image stream providing the GRETL image
+
+Add the *gretl* image stream to pull the newest GRETL image:
 ```
 oc process -f openshift/templates/gretl-is-template.yaml \
-  -p GRETL_RUNTIME_IMAGE_TAG="latest" \
+  -p GRETL_IMAGE_TAG="latest" \
   | oc apply -f -
 ```
 Parameters:
-* GRETL_RUNTIME_IMAGE_TAG: Docker image tag of GRETL runtime to be pulled from Docker Hub.
+* GRETL_IMAGE_TAG: GRETL image tag to be pulled from Docker Hub.
 * IMPORT_POLICY_SCHEDULED: Regularly check for changed image; defaults to "false"
 
 #### Create the jenkins-agent image stream providing the Jenkins agent image
@@ -66,7 +68,7 @@ Parameters:
 * JENKINS_AGENT_IMAGE_TAG: Docker image tag of Jenkins agent to be pulled from Quay.io.
 * IMPORT_POLICY_SCHEDULED: Regularly check for changed image; defaults to "false"
 
-#### Create a ConfigMap that configures the GRETL runtime Jenkins agent
+#### Create a ConfigMap that configures the Jenkins agent
 
 Adapt the OpenShift project name (and maybe the image tag) in the ConfigMap
 `openshift/templates/gretl-pod-template-configmap.yaml`,
@@ -208,14 +210,14 @@ The database connection string can then be combined with the protocol, url and d
 ## Updates
 Update an existing system.
 
-### Update GRETL runtime image
-There are several ways to change the GRETL runtime image version.
+### Update GRETL image
+There are several ways to change the GRETL image version.
 
 Either apply the `gretl-is-template.yaml` template again with the desired image tag.
 
 Or set the image tag with a command like this:
 ```
-oc tag --source=docker sogis/gretl-runtime:2.1.119 gretl:latest
+oc tag --source=docker sogis/gretl:2.1.119 gretl:latest
 ```
 
 Or edit the Image Stream manually inside the OpenShift web console:

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -42,27 +42,29 @@ Parameter:
 ### GRETL runtime
 The GRETL runtime configuration with definition of which Docker image to pull from Docker Hub.
 
-#### Create the gretl Image Stream providing the GRETL runtime image
+#### Create the gretl image stream providing the GRETL runtime image
 
-Add gretl imagestream to pull newest GRETL runtime image:
+Add the *gretl* image stream to pull the newest GRETL runtime image:
 ```
 oc process -f openshift/templates/gretl-is-template.yaml \
   -p GRETL_RUNTIME_IMAGE_TAG="latest" \
   | oc apply -f -
 ```
-Parameter:
+Parameters:
 * GRETL_RUNTIME_IMAGE_TAG: Docker image tag of GRETL runtime to be pulled from Docker Hub.
 * IMPORT_POLICY_SCHEDULED: Regularly check for changed image; defaults to "false"
 
-Basically you could add the label `role=jenkins-slave` to the image stream,
-so the OpenShift Sync plug-in, which is installed in our Jenkins,
-would automatically create the configuration
-for a Jenkins agent running the GRETL runtime image.
-Documentation: https://docs.openshift.com/container-platform/4.7/openshift_images/using_images/images-other-jenkins.html#images-other-jenkins-config-kubernetes_images-other-jenkins
-However, as we want to provide some further configuration
-of our Jenkins agent, we don't use this feature,
-but instead provide with the following steps a ConfigMap
-with the label `role=jenkins-slave`.
+#### Create the jenkins-agent image stream providing the Jenkins agent image
+
+Add the *jenkins-agent* image stream to pull a Jenkins agent image:
+```
+oc process -f openshift/templates/jenkins-agent-is-template.yaml \
+  -p JENKINS_AGENT_IMAGE_TAG=4.7 \
+  | oc apply -f -
+```
+Parameters:
+* JENKINS_AGENT_IMAGE_TAG: Docker image tag of Jenkins agent to be pulled from Quay.io.
+* IMPORT_POLICY_SCHEDULED: Regularly check for changed image; defaults to "false"
 
 #### Create a ConfigMap that configures the GRETL runtime Jenkins agent
 

--- a/openshift/templates/gretl-bigtmp-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-bigtmp-pod-template-configmap.yaml
@@ -50,6 +50,10 @@ data:
           <ttyEnabled>false</ttyEnabled>
           <envVars>
             <org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
+              <key>HOME</key>
+              <value>/home/gradle</value>
+            </org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
+            <org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
               <key>GRADLE_OPTS</key>
               <value>-Xmx1024m</value>
             </org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>

--- a/openshift/templates/gretl-bigtmp-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-bigtmp-pod-template-configmap.yaml
@@ -15,6 +15,10 @@ data:
       <label>gretl-bigtmp</label>
       <serviceAccount>jenkins</serviceAccount>
       <nodeSelector></nodeSelector>
+      <resourceRequestCpu>200m</resourceRequestCpu>
+      <resourceRequestMemory>1Gi</resourceRequestMemory>
+      <resourceLimitCpu>1</resourceLimitCpu>
+      <resourceLimitMemory>3.5Gi</resourceLimitMemory>
       <volumes>
         <org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
           <mountPath>/tmp</mountPath>
@@ -26,18 +30,24 @@ data:
       <containers>
         <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
           <name>jnlp</name>
-          <!-- Attention: Before creating this ConfigMap, please adapt the image URI below so it points to the right project -->
-          <image>image-registry.openshift-image-registry.svc:5000/PROJECT-NAME/gretl:latest</image>
+          <image>jenkins-agent:latest</image>
           <privileged>false</privileged>
           <alwaysPullImage>true</alwaysPullImage>
           <workingDir>/workspace</workingDir>
           <command></command>
           <args>${computer.jnlpmac} ${computer.name}</args>
           <ttyEnabled>false</ttyEnabled>
-          <resourceRequestCpu>200m</resourceRequestCpu>
-          <resourceRequestMemory>1Gi</resourceRequestMemory>
-          <resourceLimitCpu>1</resourceLimitCpu>
-          <resourceLimitMemory>3.5Gi</resourceLimitMemory>
+          <envVars/>
+        </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
+        <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
+          <name>gretl</name>
+          <image>gretl:latest</image>
+          <privileged>false</privileged>
+          <alwaysPullImage>true</alwaysPullImage>
+          <workingDir>/workspace</workingDir>
+          <command>sleep</command>
+          <args>24h</args>
+          <ttyEnabled>false</ttyEnabled>
           <envVars>
             <org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
               <key>GRADLE_OPTS</key>
@@ -55,7 +65,7 @@ data:
     kind: Pod
     spec:
       containers:
-        - name: jnlp
+        - name: gretl
           envFrom:
             - configMapRef:
                 name: gretl-resources

--- a/openshift/templates/gretl-bigtmp-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-bigtmp-pod-template-configmap.yaml
@@ -15,10 +15,6 @@ data:
       <label>gretl-bigtmp</label>
       <serviceAccount>jenkins</serviceAccount>
       <nodeSelector></nodeSelector>
-      <resourceRequestCpu>200m</resourceRequestCpu>
-      <resourceRequestMemory>1Gi</resourceRequestMemory>
-      <resourceLimitCpu>1</resourceLimitCpu>
-      <resourceLimitMemory>3.5Gi</resourceLimitMemory>
       <volumes>
         <org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
           <mountPath>/tmp</mountPath>
@@ -48,6 +44,10 @@ data:
           <command>sleep</command>
           <args>24h</args>
           <ttyEnabled>false</ttyEnabled>
+          <resourceRequestCpu>200m</resourceRequestCpu>
+          <resourceRequestMemory>1Gi</resourceRequestMemory>
+          <resourceLimitCpu>1</resourceLimitCpu>
+          <resourceLimitMemory>3.5Gi</resourceLimitMemory>
           <envVars>
             <org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
               <key>HOME</key>

--- a/openshift/templates/gretl-is-template.yaml
+++ b/openshift/templates/gretl-is-template.yaml
@@ -17,14 +17,14 @@ objects:
     - annotations: null
       from:
         kind: DockerImage
-        name: sogis/gretl-local:${GRETL_RUNTIME_IMAGE_TAG}
+        name: sogis/gretl:${GRETL_IMAGE_TAG}
       name: latest
       importPolicy:
         scheduled: ${{IMPORT_POLICY_SCHEDULED}}
 parameters:
-- name: GRETL_RUNTIME_IMAGE_TAG
-  description: Docker image tag of GRETL runtime to be pulled from Docker Hub.
-  displayName: Docker image tag of GRETL runtime
+- name: GRETL_IMAGE_TAG
+  description: GRETL image tag to be pulled from Docker Hub.
+  displayName: GRETL image tag
   value: latest
 - name: IMPORT_POLICY_SCHEDULED
   description: Regularly check for changed image

--- a/openshift/templates/gretl-is-template.yaml
+++ b/openshift/templates/gretl-is-template.yaml
@@ -12,7 +12,7 @@ objects:
     name: gretl
   spec:
     lookupPolicy:
-      local: false
+      local: true
     tags:
     - annotations: null
       from:

--- a/openshift/templates/gretl-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-pod-template-configmap.yaml
@@ -15,21 +15,31 @@ data:
       <label>gretl</label>
       <serviceAccount>jenkins</serviceAccount>
       <nodeSelector></nodeSelector>
+      <resourceRequestCpu>200m</resourceRequestCpu>
+      <resourceRequestMemory>1Gi</resourceRequestMemory>
+      <resourceLimitCpu>1</resourceLimitCpu>
+      <resourceLimitMemory>3.5Gi</resourceLimitMemory>
       <containers>
         <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
           <name>jnlp</name>
-          <!-- Attention: Before creating this ConfigMap, please adapt the image URI below so it points to the right project -->
-          <image>image-registry.openshift-image-registry.svc:5000/PROJECT-NAME/gretl:latest</image>
+          <image>quay.io/openshift/origin-jenkins-agent-base:latest</image>
           <privileged>false</privileged>
           <alwaysPullImage>true</alwaysPullImage>
           <workingDir>/tmp</workingDir>
           <command></command>
           <args>${computer.jnlpmac} ${computer.name}</args>
           <ttyEnabled>false</ttyEnabled>
-          <resourceRequestCpu>200m</resourceRequestCpu>
-          <resourceRequestMemory>1Gi</resourceRequestMemory>
-          <resourceLimitCpu>1</resourceLimitCpu>
-          <resourceLimitMemory>3.5Gi</resourceLimitMemory>
+          <envVars/>
+        </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
+        <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
+          <name>gretl</name>
+          <image>sogis/gretl-local:latest</image>
+          <privileged>false</privileged>
+          <alwaysPullImage>true</alwaysPullImage>
+          <workingDir>/tmp</workingDir>
+          <command>sleep</command>
+          <args>24h</args>
+          <ttyEnabled>false</ttyEnabled>
           <envVars>
             <org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
               <key>GRADLE_OPTS</key>
@@ -47,7 +57,7 @@ data:
     kind: Pod
     spec:
       containers:
-        - name: jnlp
+        - name: gretl
           envFrom:
             - configMapRef:
                 name: gretl-resources

--- a/openshift/templates/gretl-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-pod-template-configmap.yaml
@@ -22,8 +22,7 @@ data:
       <containers>
         <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
           <name>jnlp</name>
-          <!-- Attention: Before creating this ConfigMap, please adapt the image URI below so it points to the right project -->
-          <image>image-registry.openshift-image-registry.svc:5000/PROJECT-NAME/jenkins-agent:latest</image>
+          <image>jenkins-agent:latest</image>
           <privileged>false</privileged>
           <alwaysPullImage>true</alwaysPullImage>
           <workingDir>/tmp</workingDir>
@@ -34,8 +33,7 @@ data:
         </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
         <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
           <name>gretl</name>
-          <!-- Attention: Before creating this ConfigMap, please adapt the image URI below so it points to the right project -->
-          <image>image-registry.openshift-image-registry.svc:5000/PROJECT-NAME/gretl:latest</image>
+          <image>gretl:latest</image>
           <privileged>false</privileged>
           <alwaysPullImage>true</alwaysPullImage>
           <workingDir>/tmp</workingDir>

--- a/openshift/templates/gretl-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-pod-template-configmap.yaml
@@ -42,6 +42,10 @@ data:
           <ttyEnabled>false</ttyEnabled>
           <envVars>
             <org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
+              <key>HOME</key>
+              <value>/home/gradle</value>
+            </org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
+            <org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
               <key>GRADLE_OPTS</key>
               <value>-Xmx1024m</value>
             </org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>

--- a/openshift/templates/gretl-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-pod-template-configmap.yaml
@@ -15,10 +15,6 @@ data:
       <label>gretl</label>
       <serviceAccount>jenkins</serviceAccount>
       <nodeSelector></nodeSelector>
-      <resourceRequestCpu>200m</resourceRequestCpu>
-      <resourceRequestMemory>1Gi</resourceRequestMemory>
-      <resourceLimitCpu>1</resourceLimitCpu>
-      <resourceLimitMemory>3.5Gi</resourceLimitMemory>
       <containers>
         <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
           <name>jnlp</name>
@@ -40,6 +36,10 @@ data:
           <command>sleep</command>
           <args>24h</args>
           <ttyEnabled>false</ttyEnabled>
+          <resourceRequestCpu>200m</resourceRequestCpu>
+          <resourceRequestMemory>1Gi</resourceRequestMemory>
+          <resourceLimitCpu>1</resourceLimitCpu>
+          <resourceLimitMemory>3.5Gi</resourceLimitMemory>
           <envVars>
             <org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
               <key>HOME</key>

--- a/openshift/templates/gretl-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-pod-template-configmap.yaml
@@ -22,7 +22,8 @@ data:
       <containers>
         <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
           <name>jnlp</name>
-          <image>quay.io/openshift/origin-jenkins-agent-base:latest</image>
+          <!-- Attention: Before creating this ConfigMap, please adapt the image URI below so it points to the right project -->
+          <image>image-registry.openshift-image-registry.svc:5000/PROJECT-NAME/jenkins-agent:latest</image>
           <privileged>false</privileged>
           <alwaysPullImage>true</alwaysPullImage>
           <workingDir>/tmp</workingDir>
@@ -33,7 +34,8 @@ data:
         </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
         <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
           <name>gretl</name>
-          <image>sogis/gretl-local:latest</image>
+          <!-- Attention: Before creating this ConfigMap, please adapt the image URI below so it points to the right project -->
+          <image>image-registry.openshift-image-registry.svc:5000/PROJECT-NAME/gretl:latest</image>
           <privileged>false</privileged>
           <alwaysPullImage>true</alwaysPullImage>
           <workingDir>/tmp</workingDir>

--- a/openshift/templates/jenkins-agent-is-template.yaml
+++ b/openshift/templates/jenkins-agent-is-template.yaml
@@ -12,7 +12,7 @@ objects:
     name: jenkins-agent
   spec:
     lookupPolicy:
-      local: false
+      local: true
     tags:
     - annotations: null
       from:

--- a/openshift/templates/jenkins-agent-is-template.yaml
+++ b/openshift/templates/jenkins-agent-is-template.yaml
@@ -9,7 +9,7 @@ objects:
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
-    name: gretl
+    name: jenkins-agent
   spec:
     lookupPolicy:
       local: false
@@ -17,14 +17,14 @@ objects:
     - annotations: null
       from:
         kind: DockerImage
-        name: sogis/gretl-local:${GRETL_RUNTIME_IMAGE_TAG}
+        name: quay.io/openshift/origin-jenkins-agent-base:${JENKINS_AGENT_IMAGE_TAG}
       name: latest
       importPolicy:
         scheduled: ${{IMPORT_POLICY_SCHEDULED}}
 parameters:
-- name: GRETL_RUNTIME_IMAGE_TAG
-  description: Docker image tag of GRETL runtime to be pulled from Docker Hub.
-  displayName: Docker image tag of GRETL runtime
+- name: JENKINS_AGENT_IMAGE_TAG
+  description: Docker image tag of Jenkins agent to be pulled from external registry
+  displayName: Docker image tag of Jenkins agent
   value: latest
 - name: IMPORT_POLICY_SCHEDULED
   description: Regularly check for changed image


### PR DESCRIPTION
Use an updated Jenkins agent image. Instead of running one container containing the Jenkins agent and GRETL, we now use one Pod containing two containers: One runs the Jenkins agent, the other one runs GRETL.

When we merge this pull request and apply the changes, sogis/gretljobs#1038, sogis/oereb-gretljobs#165, sogis/schema-jobs#121, and sogis-oereb/oereb-gretljobs#20 must be merged as well, in order to update all Jenkinsfiles.

#### Note on the HOME variable in OpenShift Pod Template

In some cases, _ili2pg_ needs to create files like `.ilicache/jdbc&003apostgresql&003a/dbhost/edit&003fsslmode=require&0026ApplicationName=gretl/arp_npl/CoordSys-20151124.ili`. By default, it creates the `.ilicache` folder in the user's home directory. Now, Java apparently looks for the user home in `/etc/passwd` only. And OpenShift creates an entry in `/etc/passwd` for the generic user, e.g.:
```
1000910000:x:1000910000:0:1000910000 user:/:/sbin/nologin
```
This means that the user home is `/` (this is probably a Docker default), and _ili2pg_ fails to create a subdirectory in `/` because of missing permissions.

If we now set the `HOME` environment variable to `/home/gradle`, the entry in `/etc/passwd` created by OpenShift is
```
1000910000:x:1000910000:0:1000910000 user:/home/gradle:/sbin/nologin
```
As the generic user has write permissions In `/home/gradle`, _ili2pg_ can now create the `.ilicache` subfolder.

When in contrast we run the Docker container locally, there is no line in `/etc/passwd` for the user. In this case, _ili2pg_ does not fail; instead, it creates a directory called `?` inside the current directory (`pwd`) that will contain the `.ili2pg`subdirectory. (So long as it has write permissions for the current directory.)