### PR TITLE
Regularly check for changes in Jenkins agent image tag

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -62,7 +62,9 @@ oc process -f openshift/templates/jenkins-agent-is-template.yaml \
 ```
 Parameters:
 * JENKINS_AGENT_IMAGE_TAG: Docker image tag of Jenkins agent to be pulled from Quay.io.
-* IMPORT_POLICY_SCHEDULED: Regularly check for changed image; defaults to "false"
+* IMPORT_POLICY_SCHEDULED: Regularly check for changed image;
+  defaults to "true"
+  because it seems that Quay.io immediately deletes any image that has no more tag
 
 #### Create a ConfigMap that configures the Jenkins agent
 

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -68,9 +68,7 @@ Parameters:
 
 #### Create a ConfigMap that configures the Jenkins agent
 
-Adapt the OpenShift project name (and maybe the image tag) in the ConfigMap
-`openshift/templates/gretl-pod-template-configmap.yaml`,
-then apply the ConfigMap:
+Apply the ConfigMap that defines the GRETL pod (i.e. the Jenkins agent):
 ```
 oc apply -f openshift/templates/gretl-pod-template-configmap.yaml
 ```

--- a/openshift/templates/gretl-bigtmp-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-bigtmp-pod-template-configmap.yaml
@@ -28,7 +28,7 @@ data:
           <name>jnlp</name>
           <image>jenkins-agent:latest</image>
           <privileged>false</privileged>
-          <alwaysPullImage>true</alwaysPullImage>
+          <alwaysPullImage>false</alwaysPullImage>
           <workingDir>/workspace</workingDir>
           <command></command>
           <args>${computer.jnlpmac} ${computer.name}</args>
@@ -43,7 +43,7 @@ data:
           <name>gretl</name>
           <image>gretl:latest</image>
           <privileged>false</privileged>
-          <alwaysPullImage>true</alwaysPullImage>
+          <alwaysPullImage>false</alwaysPullImage>
           <workingDir>/workspace</workingDir>
           <command>sleep</command>
           <args>24h</args>

--- a/openshift/templates/gretl-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-pod-template-configmap.yaml
@@ -20,7 +20,7 @@ data:
           <name>jnlp</name>
           <image>jenkins-agent:latest</image>
           <privileged>false</privileged>
-          <alwaysPullImage>true</alwaysPullImage>
+          <alwaysPullImage>false</alwaysPullImage>
           <workingDir>/tmp</workingDir>
           <command></command>
           <args>${computer.jnlpmac} ${computer.name}</args>
@@ -35,7 +35,7 @@ data:
           <name>gretl</name>
           <image>gretl:latest</image>
           <privileged>false</privileged>
-          <alwaysPullImage>true</alwaysPullImage>
+          <alwaysPullImage>false</alwaysPullImage>
           <workingDir>/tmp</workingDir>
           <command>sleep</command>
           <args>24h</args>

--- a/openshift/templates/jenkins-agent-is-template.yaml
+++ b/openshift/templates/jenkins-agent-is-template.yaml
@@ -28,4 +28,4 @@ parameters:
   value: latest
 - name: IMPORT_POLICY_SCHEDULED
   description: Regularly check for changed image
-  value: "false"
+  value: "true"


### PR DESCRIPTION
Wenn auf Quay.io der Jenkins Agent Image Tag (z.B. 4.7) auf ein neues Image zeigt, wird offenbar das vorhergehende Image gelöscht (falls auch kein anderer Tag mehr auf das vorhergehende Image zeigt). Siehe https://docs.quay.io/guides/tag-operations.html. Deshalb ist es nötig, beim Image Stream `importPolicy: scheduled: true` zu setzen.

Gleichzeitig setzen wir bei den Pod-Templates `alwaysPullImage` auf `false`, weil sowol das Jenkins Agent Image als auch das GRETL Image in der Regel bereits auf dem Node vorhanden sind. Es wird nun nur noch gepullt, falls es nicht vorhanden ist (`ifNotPresent`). So kann der Start des Pods um ca. 2 Sekunden beschleunigt werden.

Der zweite Commit enthält eine kleine Aktualisierung der Doku.