### PR TITLE
Set resource requests and limits using YAML

### DIFF
--- a/openshift/templates/gretl-bigtmp-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-bigtmp-pod-template-configmap.yaml
@@ -69,8 +69,6 @@ data:
       <imagePullSecrets/>
       <nodeProperties/>
       <yaml>
-    apiVersion: v1
-    kind: Pod
     spec:
       containers:
         - name: gretl

--- a/openshift/templates/gretl-bigtmp-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-bigtmp-pod-template-configmap.yaml
@@ -33,10 +33,6 @@ data:
           <command></command>
           <args>${computer.jnlpmac} ${computer.name}</args>
           <ttyEnabled>false</ttyEnabled>
-          <resourceRequestCpu>200m</resourceRequestCpu>
-          <resourceRequestMemory>256Mi</resourceRequestMemory>
-          <resourceLimitCpu>1</resourceLimitCpu>
-          <resourceLimitMemory>512Mi</resourceLimitMemory>
           <envVars/>
         </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
         <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
@@ -48,10 +44,6 @@ data:
           <command>sleep</command>
           <args>24h</args>
           <ttyEnabled>false</ttyEnabled>
-          <resourceRequestCpu>200m</resourceRequestCpu>
-          <resourceRequestMemory>1Gi</resourceRequestMemory>
-          <resourceLimitCpu>1</resourceLimitCpu>
-          <resourceLimitMemory>3.5Gi</resourceLimitMemory>
           <envVars>
             <org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
               <key>HOME</key>
@@ -71,7 +63,22 @@ data:
       <yaml>
     spec:
       containers:
+      - name: jnlp
+        resources:
+          requests:
+            cpu: 200m
+            memory: 256Mi
+          limits:
+            cpu: "1"
+            memory: 512Mi
       - name: gretl
+        resources:
+          requests:
+            cpu: 200m
+            memory: 1Gi
+          limits:
+            cpu: "1"
+            memory: 3.5Gi
         envFrom:
           - configMapRef:
               name: gretl-resources

--- a/openshift/templates/gretl-bigtmp-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-bigtmp-pod-template-configmap.yaml
@@ -71,11 +71,11 @@ data:
       <yaml>
     spec:
       containers:
-        - name: gretl
-          envFrom:
-            - configMapRef:
-                name: gretl-resources
-            - secretRef:
-                name: gretl-secrets
+      - name: gretl
+        envFrom:
+          - configMapRef:
+              name: gretl-resources
+          - secretRef:
+              name: gretl-secrets
       </yaml>
     </org.csanchez.jenkins.plugins.kubernetes.PodTemplate>

--- a/openshift/templates/gretl-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-pod-template-configmap.yaml
@@ -63,11 +63,11 @@ data:
       <yaml>
     spec:
       containers:
-        - name: gretl
-          envFrom:
-            - configMapRef:
-                name: gretl-resources
-            - secretRef:
-                name: gretl-secrets
+      - name: gretl
+        envFrom:
+          - configMapRef:
+              name: gretl-resources
+          - secretRef:
+              name: gretl-secrets
       </yaml>
     </org.csanchez.jenkins.plugins.kubernetes.PodTemplate>

--- a/openshift/templates/gretl-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-pod-template-configmap.yaml
@@ -61,8 +61,6 @@ data:
       <imagePullSecrets/>
       <nodeProperties/>
       <yaml>
-    apiVersion: v1
-    kind: Pod
     spec:
       containers:
         - name: gretl

--- a/openshift/templates/gretl-pod-template-configmap.yaml
+++ b/openshift/templates/gretl-pod-template-configmap.yaml
@@ -25,10 +25,6 @@ data:
           <command></command>
           <args>${computer.jnlpmac} ${computer.name}</args>
           <ttyEnabled>false</ttyEnabled>
-          <resourceRequestCpu>200m</resourceRequestCpu>
-          <resourceRequestMemory>256Mi</resourceRequestMemory>
-          <resourceLimitCpu>1</resourceLimitCpu>
-          <resourceLimitMemory>512Mi</resourceLimitMemory>
           <envVars/>
         </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
         <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
@@ -40,10 +36,6 @@ data:
           <command>sleep</command>
           <args>24h</args>
           <ttyEnabled>false</ttyEnabled>
-          <resourceRequestCpu>200m</resourceRequestCpu>
-          <resourceRequestMemory>1Gi</resourceRequestMemory>
-          <resourceLimitCpu>1</resourceLimitCpu>
-          <resourceLimitMemory>3.5Gi</resourceLimitMemory>
           <envVars>
             <org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
               <key>HOME</key>
@@ -63,7 +55,22 @@ data:
       <yaml>
     spec:
       containers:
+      - name: jnlp
+        resources:
+          requests:
+            cpu: 200m
+            memory: 256Mi
+          limits:
+            cpu: "1"
+            memory: 512Mi
       - name: gretl
+        resources:
+          requests:
+            cpu: 200m
+            memory: 1Gi
+          limits:
+            cpu: "1"
+            memory: 3.5Gi
         envFrom:
           - configMapRef:
               name: gretl-resources


### PR DESCRIPTION
Set resource requests and limits using YAML. This way, in a Jenkinsfile an agent can be defined that overrides these values. See https://github.com/sogis/gretljobs/pull/1122, line 12 of the Jenkinsfile.

Additionally, some more refactoring has been done in two other commits.