### PR TITLE
Reduce image size

### DIFF
--- a/runtimeImage/gretl/Dockerfile
+++ b/runtimeImage/gretl/Dockerfile
@@ -3,6 +3,7 @@ FROM bellsoft/liberica-openjdk-alpine:8u322-6
 CMD ["gretl"]
 
 WORKDIR /home/gradle
+RUN chmod g+w .
 
 RUN apk add --no-cache bash
 
@@ -24,14 +25,12 @@ RUN set -o errexit -o nounset \
     && ln -s "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle \
     \
     && echo "Testing Gradle installation" \
-    && gradle --version
+    && (umask 0002 && gradle --version)
 
 ENV ILI_CACHE=/home/gradle/.ilicache
 COPY gretl /usr/local/bin/
 COPY __jars4image /home/gradle/libs/
 COPY init.gradle /home/gradle/
-
-RUN chmod -R g+w /home/gradle
 
 RUN apk add --no-cache curl
 
@@ -40,5 +39,6 @@ RUN ls -la /usr/local/bin/  && \
     ls -la /home/gradle/libs
 
 WORKDIR /home/gradle/project
+RUN chmod g+w .
 
 USER 1001


### PR DESCRIPTION
`RUN chmod -R g+w /home/gradle` machte das Image ca. 70MB grösser als nötig.

Stattdessen die folgenden Änderungen:
* Der Befehl `gradle --version` generiert diverse Verzeichnisse und Dateien innerhalb von `/home/gradle`. Damit diese gleich beim Erstellen Schreibrechte auch für die Gruppe erhalten und also ein `chmod` gar nicht mehr nötig ist, wird vorgängig `umask 0002` gesetzt (sie wäre standardmässig 0022). Damit dieser Befehl nur für den Befehl `gradle --version` gilt, wird er innerhalb der Klammern geschrieben, wodurch eine Subshell gestartet wird (Details siehe z.B. https://unix.stackexchange.com/a/65890).
* Dort, wo durch den Befehl `WORKDIR` ein Verzeichnis angelegt wird, in welchem Schreibrechte nötig sind, folgt gleich im Anschluss ein `RUN chmod g+w`. Zu diesem Zeitpunkt ist das Verzeichnis noch leer, so dass das Image nicht grösser wird.