### PR TITLE
Remove stacktrace option

### DIFF
--- a/runtimeImage/gretl/gretl
+++ b/runtimeImage/gretl/gretl
@@ -8,5 +8,4 @@ fi
 
 gradle $run_parameter \
        --init-script /home/gradle/init.gradle \
-       --stacktrace \
        --no-daemon


### PR DESCRIPTION
Mir scheint, dass `--stacktrace` nur dafür sorgt, dass am Schluss unter "What went wrong" nochmal das Stacktrace von weiter oben wiederholt wird. Ich würde es deshalb herausnehmen.

@edigonzales Merge es gleich selber, falls du einverstanden bist.