### PR TITLE
Support for parameter metaConfig

### DIFF
--- a/gretl/src/integrationTest/java/ch/so/agi/gretl/jobs/Ili2pgImportSchemaTest.java
+++ b/gretl/src/integrationTest/java/ch/so/agi/gretl/jobs/Ili2pgImportSchemaTest.java
@@ -113,4 +113,58 @@ public class Ili2pgImportSchemaTest {
         }
     }
 
+    @Test
+    public void schemaImport_MetaConfigIliData_Ok() throws Exception {
+        Connection con = null;
+        try {
+            GradleVariable[] gvs = {GradleVariable.newGradleProperty(IntegrationTestUtilSql.VARNAME_PG_CON_URI, postgres.getJdbcUrl())};
+            IntegrationTestUtil.runJob("src/integrationTest/jobs/Ili2pgImportSchema_MetaConfigIliData", gvs);
+
+            // check results
+            con = IntegrationTestUtilSql.connectPG(postgres);
+            Statement s = con.createStatement();
+            ResultSet rs = s.executeQuery("SELECT setting FROM afu_schutzbauten_ilidata.t_ili2db_settings WHERE tag ILIKE 'ch.ehi.ili2db.metaConfigFileName'");
+
+            if(!rs.next()) {
+                fail();
+            }
+
+            assertTrue(rs.getString(1).contains("ilidata:metaconfig_so_afu_schutzbauten_20231212_ohne_constraints_ini_001"));
+
+            if(rs.next()) {
+                fail();
+            }
+
+        } finally {
+            IntegrationTestUtilSql.closeCon(con);
+        }
+    }
+
+    @Test
+    public void schemaImport_MetaConfigFile_Ok() throws Exception {
+        Connection con = null;
+        try {
+            GradleVariable[] gvs = {GradleVariable.newGradleProperty(IntegrationTestUtilSql.VARNAME_PG_CON_URI, postgres.getJdbcUrl())};
+            IntegrationTestUtil.runJob("src/integrationTest/jobs/Ili2pgImportSchema_MetaConfigFile", gvs);
+
+            // check results
+            con = IntegrationTestUtilSql.connectPG(postgres);
+            Statement s = con.createStatement();
+            ResultSet rs = s.executeQuery("SELECT setting FROM afu_schutzbauten_file.t_ili2db_settings WHERE tag ILIKE 'ch.ehi.ili2db.metaConfigFileName'");
+
+            if(!rs.next()) {
+                fail();
+            }
+
+            assertTrue(rs.getString(1).contains("so_afu_schutzbauten_20231212_ohne_constraints.ini"));
+
+            if(rs.next()) {
+                fail();
+            }
+
+        } finally {
+            IntegrationTestUtilSql.closeCon(con);
+        }
+    }
+
 }

--- a/gretl/src/integrationTest/java/ch/so/agi/gretl/jobs/Ili2pgImportSchemaTest.java
+++ b/gretl/src/integrationTest/java/ch/so/agi/gretl/jobs/Ili2pgImportSchemaTest.java
@@ -123,13 +123,13 @@ public class Ili2pgImportSchemaTest {
             // check results
             con = IntegrationTestUtilSql.connectPG(postgres);
             Statement s = con.createStatement();
-            ResultSet rs = s.executeQuery("SELECT setting FROM afu_schutzbauten_ilidata.t_ili2db_settings WHERE tag ILIKE 'ch.ehi.ili2db.metaConfigFileName'");
+            ResultSet rs = s.executeQuery("SELECT setting FROM simple_table_ilidata.t_ili2db_settings WHERE tag ILIKE 'ch.ehi.ili2db.metaConfigFileName'");
 
             if(!rs.next()) {
                 fail();
             }
 
-            assertTrue(rs.getString(1).contains("ilidata:metaconfig_so_afu_schutzbauten_20231212_ohne_constraints_ini_001"));
+            assertTrue(rs.getString(1).contains("ilidata:metaconfig_simple_table_ini_20240502"));
 
             if(rs.next()) {
                 fail();
@@ -150,13 +150,13 @@ public class Ili2pgImportSchemaTest {
             // check results
             con = IntegrationTestUtilSql.connectPG(postgres);
             Statement s = con.createStatement();
-            ResultSet rs = s.executeQuery("SELECT setting FROM afu_schutzbauten_file.t_ili2db_settings WHERE tag ILIKE 'ch.ehi.ili2db.metaConfigFileName'");
+            ResultSet rs = s.executeQuery("SELECT setting FROM simple_table_metaconfigfile.t_ili2db_settings WHERE tag ILIKE 'ch.ehi.ili2db.metaConfigFileName'");
 
             if(!rs.next()) {
                 fail();
             }
 
-            assertTrue(rs.getString(1).contains("so_afu_schutzbauten_20231212_ohne_constraints.ini"));
+            assertTrue(rs.getString(1).contains("simple_table_ini_20240502.ini"));
 
             if(rs.next()) {
                 fail();

--- a/gretl/src/integrationTest/jobs/Ili2pgImportSchema_MetaConfigFile/SimpleTable.ili
+++ b/gretl/src/integrationTest/jobs/Ili2pgImportSchema_MetaConfigFile/SimpleTable.ili
@@ -1,0 +1,21 @@
+INTERLIS 2.3;
+
+MODEL SimpleTable (de)
+AT "mailto:agi@bd.so.ch"
+VERSION "2024-05-02"  =
+
+  DOMAIN
+
+    LKoord = COORD 2460000.000 .. 2870000.000 [INTERLIS.M], 1045000.000 .. 1310000.000 [INTERLIS.M] ,ROTATION 2 -> 1;
+
+  TOPIC SimpleTopic =
+
+    CLASS Table =
+      Anzahl : MANDATORY 1 .. 1000;
+      Bezeichnung : MANDATORY MTEXT*64;
+      Geometrie : MANDATORY SimpleTable.LKoord;
+    END Table;
+
+  END SimpleTopic;
+
+END SimpleTable.

--- a/gretl/src/integrationTest/jobs/Ili2pgImportSchema_MetaConfigFile/build.gradle
+++ b/gretl/src/integrationTest/jobs/Ili2pgImportSchema_MetaConfigFile/build.gradle
@@ -12,6 +12,7 @@ defaultTasks 'ili2pgschemaimport'
 
 task ili2pgschemaimport(type: Ili2pgImportSchema){
     database = [db_uri, db_user, db_pass]
-    dbschema = "afu_schutzbauten_file"
-    metaConfig = "so_afu_schutzbauten_20231212_ohne_constraints.ini"
+    dbschema = "simple_table_metaconfigfile"
+    modeldir = "%ILI_FROM_DB;" + rootProject.projectDir.toString() + ";https://geo.so.ch/models;http://models.interlis.ch"
+    metaConfig = "simple_table_ini_20240502.ini"
 }

--- a/gretl/src/integrationTest/jobs/Ili2pgImportSchema_MetaConfigFile/build.gradle
+++ b/gretl/src/integrationTest/jobs/Ili2pgImportSchema_MetaConfigFile/build.gradle
@@ -1,0 +1,17 @@
+import ch.so.agi.gretl.tasks.*
+
+apply plugin: 'ch.so.agi.gretl'
+
+def GRETLTEST_DBURI = 'gretltest_dburi_pg'
+def db_uri = findProperty(GRETLTEST_DBURI) != null ? findProperty(GRETLTEST_DBURI) : 'jdbc:postgresql://localhost:5432/gretl'
+
+def db_user = "ddluser"
+def db_pass = "ddluser"
+
+defaultTasks 'ili2pgschemaimport'
+
+task ili2pgschemaimport(type: Ili2pgImportSchema){
+    database = [db_uri, db_user, db_pass]
+    dbschema = "afu_schutzbauten_file"
+    metaConfig = "so_afu_schutzbauten_20231212_ohne_constraints.ini"
+}

--- a/gretl/src/integrationTest/jobs/Ili2pgImportSchema_MetaConfigFile/simple_table_ini_20240502.ini
+++ b/gretl/src/integrationTest/jobs/Ili2pgImportSchema_MetaConfigFile/simple_table_ini_20240502.ini
@@ -1,9 +1,5 @@
-[CONFIGURATION]
-qgis.modelbaker.projecttopping = ilidata:projecttopping_so_afu_schutzbauten_20231212_ohne_constraints_yaml_001
-qgis.modelbaker.metaConfigParamsOnly = True
-
 [ch.ehi.ili2db]
-models = SO_AFU_Schutzbauten_20231212
+models = SimpleTable
 beautifyEnumDispName = True
 coalesceArray = True
 coalesceCatalogueRef = True

--- a/gretl/src/integrationTest/jobs/Ili2pgImportSchema_MetaConfigFile/so_afu_schutzbauten_20231212_ohne_constraints.ini
+++ b/gretl/src/integrationTest/jobs/Ili2pgImportSchema_MetaConfigFile/so_afu_schutzbauten_20231212_ohne_constraints.ini
@@ -1,0 +1,28 @@
+[CONFIGURATION]
+qgis.modelbaker.projecttopping = ilidata:projecttopping_so_afu_schutzbauten_20231212_ohne_constraints_yaml_001
+qgis.modelbaker.metaConfigParamsOnly = True
+
+[ch.ehi.ili2db]
+models = SO_AFU_Schutzbauten_20231212
+beautifyEnumDispName = True
+coalesceArray = True
+coalesceCatalogueRef = True
+coalesceMultiLine = True
+coalesceMultiPoint = True
+coalesceMultiSurface = True
+createBasketCol = False
+createEnumTabs = True
+createEnumTabsWithId = False
+createNumChecks = False
+createUnique = False
+createFk = True
+createFkIdx = True
+createMetaInfo = True
+createTidCol = True
+createTypeConstraint = False
+defaultSrsAuth = EPSG
+defaultSrsCode = 2056
+expandMultilingual = True
+smart2Inheritance = True
+sqlEnableNull = True
+strokeArcs = True

--- a/gretl/src/integrationTest/jobs/Ili2pgImportSchema_MetaConfigIliData/SimpleTable.ili
+++ b/gretl/src/integrationTest/jobs/Ili2pgImportSchema_MetaConfigIliData/SimpleTable.ili
@@ -1,0 +1,21 @@
+INTERLIS 2.3;
+
+MODEL SimpleTable (de)
+AT "mailto:agi@bd.so.ch"
+VERSION "2024-05-02"  =
+
+  DOMAIN
+
+    LKoord = COORD 2460000.000 .. 2870000.000 [INTERLIS.M], 1045000.000 .. 1310000.000 [INTERLIS.M] ,ROTATION 2 -> 1;
+
+  TOPIC SimpleTopic =
+
+    CLASS Table =
+      Anzahl : MANDATORY 1 .. 1000;
+      Bezeichnung : MANDATORY MTEXT*64;
+      Geometrie : MANDATORY SimpleTable.LKoord;
+    END Table;
+
+  END SimpleTopic;
+
+END SimpleTable.

--- a/gretl/src/integrationTest/jobs/Ili2pgImportSchema_MetaConfigIliData/build.gradle
+++ b/gretl/src/integrationTest/jobs/Ili2pgImportSchema_MetaConfigIliData/build.gradle
@@ -1,0 +1,17 @@
+import ch.so.agi.gretl.tasks.*
+
+apply plugin: 'ch.so.agi.gretl'
+
+def GRETLTEST_DBURI = 'gretltest_dburi_pg'
+def db_uri = findProperty(GRETLTEST_DBURI) != null ? findProperty(GRETLTEST_DBURI) : 'jdbc:postgresql://localhost:5432/gretl'
+
+def db_user = "ddluser"
+def db_pass = "ddluser"
+
+defaultTasks 'ili2pgschemaimport'
+
+task ili2pgschemaimport(type: Ili2pgImportSchema){
+    database = [db_uri, db_user, db_pass]
+    dbschema = "afu_schutzbauten_ilidata"
+    metaConfig = "ilidata:metaconfig_so_afu_schutzbauten_20231212_ohne_constraints_ini_001"
+}

--- a/gretl/src/integrationTest/jobs/Ili2pgImportSchema_MetaConfigIliData/build.gradle
+++ b/gretl/src/integrationTest/jobs/Ili2pgImportSchema_MetaConfigIliData/build.gradle
@@ -12,6 +12,7 @@ defaultTasks 'ili2pgschemaimport'
 
 task ili2pgschemaimport(type: Ili2pgImportSchema){
     database = [db_uri, db_user, db_pass]
-    dbschema = "afu_schutzbauten_ilidata"
-    metaConfig = "ilidata:metaconfig_so_afu_schutzbauten_20231212_ohne_constraints_ini_001"
+    dbschema = "simple_table_ilidata"
+    modeldir = "%ILI_FROM_DB;" + rootProject.projectDir.toString() + ";https://geo.so.ch/models;http://models.interlis.ch"
+    metaConfig = "ilidata:metaconfig_simple_table_ini_20240502"
 }

--- a/gretl/src/integrationTest/jobs/Ili2pgImportSchema_MetaConfigIliData/files/simple_table_ini_20240502.ini
+++ b/gretl/src/integrationTest/jobs/Ili2pgImportSchema_MetaConfigIliData/files/simple_table_ini_20240502.ini
@@ -1,0 +1,24 @@
+[ch.ehi.ili2db]
+models = SimpleTable
+beautifyEnumDispName = True
+coalesceArray = True
+coalesceCatalogueRef = True
+coalesceMultiLine = True
+coalesceMultiPoint = True
+coalesceMultiSurface = True
+createBasketCol = False
+createEnumTabs = True
+createEnumTabsWithId = False
+createNumChecks = False
+createUnique = False
+createFk = True
+createFkIdx = True
+createMetaInfo = True
+createTidCol = True
+createTypeConstraint = False
+defaultSrsAuth = EPSG
+defaultSrsCode = 2056
+expandMultilingual = True
+smart2Inheritance = True
+sqlEnableNull = True
+strokeArcs = True

--- a/gretl/src/integrationTest/jobs/Ili2pgImportSchema_MetaConfigIliData/ilidata.xml
+++ b/gretl/src/integrationTest/jobs/Ili2pgImportSchema_MetaConfigIliData/ilidata.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?><TRANSFER xmlns="http://www.interlis.ch/INTERLIS2.3">
+    <HEADERSECTION SENDER="SOGIS-INTERLIS-REPOSITORY-CREATOR" VERSION="2.3">
+        <MODELS>
+            <MODEL NAME="DatasetIdx16" VERSION="2022-10-10" URI="mailto:ce@eisenhutinformatik.ch"></MODEL>
+        </MODELS>
+    </HEADERSECTION>
+    <DATASECTION>
+        <DatasetIdx16.DataIndex BID="b1">
+            <DatasetIdx16.DataIndex.DatasetMetadata TID="037f8229-ac14-42de-a299-81038f229790">
+                <id>metaconfig_simple_table_ini_20240502</id>
+                <version>2024-02-18</version>
+                <publishingDate>2024-02-18</publishingDate>
+                <owner>mailto:bjsvwweb</owner>
+                <title>
+                    <DatasetIdx16.MultilingualText>
+                        <LocalisedText>
+                            <DatasetIdx16.LocalisedText>
+                                <Text>simple_table_ini_20240502</Text>
+                            </DatasetIdx16.LocalisedText>
+                        </LocalisedText>
+                    </DatasetIdx16.MultilingualText>
+                </title>
+                <shortDescription>
+                    <DatasetIdx16.MultilingualMText>
+                        <LocalisedText>
+                            <DatasetIdx16.LocalisedMText>
+                                <Text>Metaconfig file for simple_table_ini_20240502 - ('simple_table_ini_20240502', '.ini')</Text>
+                            </DatasetIdx16.LocalisedMText>
+                        </LocalisedText>
+                    </DatasetIdx16.MultilingualMText>
+                </shortDescription>
+                <categories>
+                    <DatasetIdx16.Code_>
+                        <value>http://codes.interlis.ch/type/metaconfig</value>
+                    </DatasetIdx16.Code_>
+                    <DatasetIdx16.Code_>
+                        <value>http://codes.interlis.ch/model/SO_AFU_Schutzbauten_20231212</value>
+                    </DatasetIdx16.Code_>
+                </categories>
+                <files>
+                    <DatasetIdx16.DataFile>
+                        <fileFormat>text/plain</fileFormat>
+                        <file>
+                            <DatasetIdx16.File>
+                                <path>files/simple_table_ini_20240502.ini</path>
+                            </DatasetIdx16.File>
+                        </file>
+                    </DatasetIdx16.DataFile>
+                </files>
+            </DatasetIdx16.DataIndex.DatasetMetadata>
+        </DatasetIdx16.DataIndex>
+    </DATASECTION>
+</TRANSFER>

--- a/gretl/src/main/java/ch/so/agi/gretl/tasks/Ili2pgImportSchema.java
+++ b/gretl/src/main/java/ch/so/agi/gretl/tasks/Ili2pgImportSchema.java
@@ -79,10 +79,10 @@ public class Ili2pgImportSchema extends Ili2pgAbstractTask {
     public boolean expandMultilingual = false;
     @Input
     @Optional
-    public boolean coalesceJson = false;    
+    public boolean coalesceJson = false;
     @Input
     @Optional
-    public boolean coalesceArray = false; 
+    public boolean coalesceArray = false;
     @Input
     @Optional
     public boolean createTypeConstraint = false;
@@ -158,6 +158,9 @@ public class Ili2pgImportSchema extends Ili2pgAbstractTask {
     @Input
     @Optional
     public boolean createMetaInfo = false;
+    @Input
+    @Optional
+    public String metaConfig = null;
 
     @TaskAction
     public void importSchema() {
@@ -174,12 +177,12 @@ public class Ili2pgImportSchema extends Ili2pgAbstractTask {
             }
         }
         settings.setXtffile(iliFilename);
-        
+
         if (iliMetaAttrs != null) {
             String iliMetaAttrsFilename = this.getProject().file(iliMetaAttrs).getPath();
             settings.setIliMetaAttrsFile(iliMetaAttrsFilename);
         }
-        
+
         init(settings);
         run(function, settings);
     }
@@ -329,6 +332,16 @@ public class Ili2pgImportSchema extends Ili2pgAbstractTask {
         }
         if (createMetaInfo) {
             settings.setCreateMetaInfo(true);
+        }
+        if (metaConfig != null) {
+            String metaConfigFile = null;
+            if (metaConfig.startsWith("ilidata")) {
+                metaConfigFile = metaConfig;
+            } else {
+                java.io.File file = this.getProject().file(metaConfig);
+                metaConfigFile = file.getAbsolutePath();
+            }
+            settings.setMetaConfigFile(metaConfigFile);
         }
     }
 }

--- a/runtimeImage/start-gretl.sh
+++ b/runtimeImage/start-gretl.sh
@@ -41,5 +41,5 @@ docker run -i --rm \
     --network="host" \
     -v "$job_directory":/home/gradle/project \
     --user $UID \
-    sogis/gretl "-c" \
+    sogis/gretl:2.4 "-c" \
         "/usr/local/bin/run-jnlp-client > /dev/null 2>&1;cd /home/gradle/project;$gretl_cmd"


### PR DESCRIPTION
Mit einer Umsetzung des Parameters _metaConfig_ (und der _ilidata:_ Syntax):
* man nehme eine Meta Konfiguration vom UsabilityHub z.B. https://geo.so.ch/usabilityhub/so_afu_schutzbauten_20231212_ohne_constraints/metaconfig/so_afu_schutzbauten_20231212_ohne_constraints.ini
* entsprechend dieser Konfiguration wird Datenbank in Schema Job erstellt
* in der Tabelle _t_ili2db_settings_ wird die Meta Konfiguration auch abgelegt
* Model Baker erkennt die Meta Konfiguration und das entsprechende Topping vom UsabilityHub:
  * keine Auswahl des Toppings in Model Baker nötig
  * Topping aus UsabilityHub passt garantiert auf Abbildungsregeln von ili2db
  * ein GIS-Bearbeiter muss nur das richtige Schema angeben und dann den Wizard durchklicken

![image](https://github.com/sogis/gretl/assets/980073/d7d40932-8dc8-41f3-8a6c-73826d0a9cc1)

@edigonzales Macht so etwas Sinn, oder widespricht dies unseren Schema Job Grundsätzen?