### PR TITLE
feat: use maxParallelForks

### DIFF
--- a/gretl/build.gradle
+++ b/gretl/build.gradle
@@ -173,6 +173,7 @@ tasks.register('setupPluginUpload'){
 tasks.publishPlugins.dependsOn tasks.setupPluginUpload
 
 test {
+    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
     useJUnit{
         // Exclude all Tests with dependency to a db server (pg, oracle, ..)
         excludeCategories 'ch.so.agi.gretl.testutil.DbTest'


### PR DESCRIPTION
This PR adds maxParallelForks settings to build.gradle.
The value comes from the Gradle documentation - https://docs.gradle.org/current/userguide/performance.html#execute_tests_in_parallel

