### PR TITLE
fix: Funktion wird nicht gefunden für IliValidator Task

### DIFF
--- a/gretl/src/main/java/ch/so/agi/gretl/tasks/IliValidator.java
+++ b/gretl/src/main/java/ch/so/agi/gretl/tasks/IliValidator.java
@@ -54,14 +54,19 @@ public class IliValidator extends AbstractValidatorTask {
         userFunctionList.add("ch.so.agi.ilivalidator.ext.IsValidDocumentsCycleIoxPlugin");
         userFunctionList.add("ch.so.agi.ilivalidator.ext.RingSelfIntersectionIoxPlugin");
         userFunctionList.add("ch.so.agi.ilivalidator.ext.TooFewPointsPolylineIoxPlugin");
-
+        //userFunctionList.add("ch.so.agi.ilivalidator.ext.IsHttpResourceFromOerebMultilingualUriIoxPlugin");
         userFunctionList.add("ch.geowerkstatt.ilivalidator.extensions.functions.GetAreaIoxPlugin");
         userFunctionList.add("ch.geowerkstatt.ilivalidator.extensions.functions.GetLengthIoxPlugin");
         userFunctionList.add("ch.geowerkstatt.ilivalidator.extensions.functions.GetInnerRingsCountIoxPlugin");
         userFunctionList.add("ch.geowerkstatt.ilivalidator.extensions.functions.GetInGroupsIoxPlugin");
-        userFunctionList.add("ch.geowerkstatt.ilivalidator.extensions.functions.IsInsideExternalDatasetIoxPlugin");
-        userFunctionList.add("ch.geowerkstatt.ilivalidator.extensions.functions.IsInsideExternalDatasetResourceIoxPlugin");
+        userFunctionList.add("ch.geowerkstatt.ilivalidator.extensions.functions.IsInsideExternalXtfIoxPlugin");
+        userFunctionList.add("ch.geowerkstatt.ilivalidator.extensions.functions.IsInsideExternalXtfResourceIoxPlugin");
+        userFunctionList.add("ch.geowerkstatt.ilivalidator.extensions.functions.IsInsideIoxPlugin");
+        userFunctionList.add("ch.geowerkstatt.ilivalidator.extensions.functions.UnionIoxPlugin");
         userFunctionList.add("ch.geowerkstatt.ilivalidator.extensions.functions.PolylinesOverlapIoxPlugin");
+        userFunctionList.add("ch.geowerkstatt.ilivalidator.extensions.functions.FindObjectsIoxPlugin");
+        userFunctionList.add("ch.geowerkstatt.ilivalidator.extensions.functions.FilterIoxPlugin");
+//        userFunctionList.add("ch.geowerkstatt.ilivalidator.extensions.functions.ngk.IsInsideAreaByCodeIoxPlugin");
 
         Map<String,Class> userFunctions = new HashMap<String,Class>();
         try {


### PR DESCRIPTION
I re-used logic from https://github.com/sogis/gretl/blob/V2_4_x/gretl/src/main/java/ch/so/agi/gretl/tasks/IliValidator.java#L50 as mentioned in the ticket.