### PR TITLE
Move Docker build to Gradle tasks 

### DIFF
--- a/.github/workflows/gretl.yml
+++ b/.github/workflows/gretl.yml
@@ -27,27 +27,26 @@ jobs:
         run: ./gradlew clean gretl:classes 
 
       - name: Unit tests and publish plugin to local maven repo
-        # run: |
-        #   TZ="Europe/Zurich" ./gradlew gretl:test gretl:dbTest gretl:s3Test
-        #   ./gradlew gretl:build gretl:publishPluginMavenPublicationToMavenLocal -x test
         run: |
+          TZ="Europe/Zurich" ./gradlew gretl:test gretl:dbTest gretl:s3Test
           ./gradlew gretl:build gretl:publishPluginMavenPublicationToMavenLocal -x test
+        # run: |
+        #   ./gradlew gretl:build gretl:publishPluginMavenPublicationToMavenLocal -x test
 
-      # - name: Integration tests (Plugin)
-      #   id: jarTest
-      #   run: |
-      #     TZ="Europe/Zurich" ./gradlew gretl:jarTest gretl:jarS3Test
-
-      # - uses: actions/upload-artifact@v4
-      #   if: always() && (steps.jarTest.outcome == 'failure')
-      #   with:
-      #     name: reports-jar
-      #     path: gretl/build/reports/tests/
-
-      - name: Stage jar files
+      - name: Debug1
         run: |
-          ./gradlew runtimeImage:stageJars
-          ls -la runtimeImage/gretl/__jars4image
+          ls -la ~/.m2/repository/ch/so/agi/gretl
+
+      - name: Integration tests (Plugin)
+        id: jarTest
+        run: |
+          TZ="Europe/Zurich" ./gradlew gretl:jarTest gretl:jarS3Test
+
+      - uses: actions/upload-artifact@v4
+        if: always() && (steps.jarTest.outcome == 'failure')
+        with:
+          name: reports-jar
+          path: gretl/build/reports/tests/
 
       - name: Build Docker image for integration tests
         run: |
@@ -57,11 +56,43 @@ jobs:
         run: |
           docker images
 
-      - name: Integration tests (Docker Image)
-        # run: |
-        #   TZ="Europe/Zurich" ./gradlew gretl:imageTest gretl:imageS3Test
+      - name: Integration tests (Docker image)
+        id: imageTest
         run: |
-          TZ="Europe/Zurich" ./gradlew gretl:imageTest --tests ch.so.agi.gretl.jobs.XslTransformerTest
+          TZ="Europe/Zurich" ./gradlew gretl:imageTest gretl:imageS3Test
+        # run: |
+        #   TZ="Europe/Zurich" ./gradlew gretl:imageTest --tests ch.so.agi.gretl.jobs.XslTransformerTest
+
+      - uses: actions/upload-artifact@v4
+        if: always() && (steps.imageTest.outcome == 'failure')
+        with:
+          name: reports-image
+          path: gretl/build/reports/tests/
+
+      - name: Login to Docker Container Registry
+        if: ${{ (github.ref == 'refs/heads/main') && (github.event_name != 'pull_request') && !env.ACT }}
+        uses: docker/login-action@v2
+        with:
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        if: ${{ (github.ref == 'refs/heads/main') && (github.event_name != 'pull_request') && !env.ACT }}
+        uses: docker/setup-buildx-action@v2
+
+      - name: Publish plugin
+        if: ${{ (github.ref == 'refs/heads/main') && (github.event_name != 'pull_request') && !env.ACT }}
+        run: ./gradlew gretl:publishPlugins -s
+        env:
+          gradlePublishKey: ${{ secrets.GRADLEPUBLISHKEY }}
+          gradlePublishSecret: ${{ secrets.GRADLEPUBLISHSECRET }}
+
+      - name: Build final multi-arch Docker image and push to registry 
+        if: ${{ (github.ref == 'refs/heads/main') && (github.event_name != 'pull_request') && !env.ACT }}
+        run: |
+          ./gradlew runtimeImage:buildAndPushMultiArchImage
+
+
 
 
       # - name: Debug1

--- a/.github/workflows/gretl.yml
+++ b/.github/workflows/gretl.yml
@@ -57,6 +57,13 @@ jobs:
         run: |
           docker images
 
+      - name: Integration tests (Docker Image)
+        # run: |
+        #   TZ="Europe/Zurich" ./gradlew gretl:imageTest gretl:imageS3Test
+        run: |
+          TZ="Europe/Zurich" ./gradlew gretl:imageTest --tests ch.so.agi.gretl.jobs.XslTransformerTest
+
+
       # - name: Debug1
       #   run: |
       #     ls -la ~/.m2/repository/ch/so/agi/gretl

--- a/.github/workflows/gretl.yml
+++ b/.github/workflows/gretl.yml
@@ -7,141 +7,131 @@ on:
       - 'docs/**'
       - 'openshift/**'
       - '**.md'
-    branches-ignore:
-      - publisher
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       BUILD_NUMBER: ${{ github.run_number }}
     steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/cache@v1
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'temurin'
+          cache: 'gradle'
 
       - name: Build with Gradle
         run: ./gradlew clean gretl:classes 
 
-      - name: Unit Tests and publish plugin to local maven repo
-        run: |
-          TZ="Europe/Zurich" ./gradlew gretl:test gretl:dbTest
-          ./gradlew clean gretl:s3Test -Ds3AccessKey=$S3_ACCESS_KEY -Ds3SecretKey=$S3_SECRET_KEY -Ds3BucketName=ch.so.agi.gretl.test
-          ./gradlew gretl:build gretl:publishPluginMavenPublicationToMavenLocal -x test
+      - name: Unit tests and publish plugin to local maven repo
         # run: |
+        #   TZ="Europe/Zurich" ./gradlew gretl:test gretl:dbTest gretl:s3Test
         #   ./gradlew gretl:build gretl:publishPluginMavenPublicationToMavenLocal -x test
-        env:
-          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
-          S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
-
-      - name: Integration Test (Jar)
         run: |
-          TZ="Europe/Zurich" ./gradlew gretl:jarTest
-          ./gradlew gretl:jarS3Test -Ds3AccessKey=$S3_ACCESS_KEY -Ds3SecretKey=$S3_SECRET_KEY -Ds3BucketName=ch.so.agi.gretl.test
-        env:
-          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
-          S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+          ./gradlew gretl:build gretl:publishPluginMavenPublicationToMavenLocal -x test
 
-      - uses: actions/upload-artifact@v3
-        if: ${{ failure() }}
-        with:
-          name: reports-jar
-          path: gretl/build/reports/tests/
+      # - name: Integration tests (Plugin)
+      #   id: jarTest
+      #   run: |
+      #     TZ="Europe/Zurich" ./gradlew gretl:jarTest gretl:jarS3Test
+
+      # - uses: actions/upload-artifact@v4
+      #   if: always() && (steps.jarTest.outcome == 'failure')
+      #   with:
+      #     name: reports-jar
+      #     path: gretl/build/reports/tests/
 
       - name: Stage jar files
         run: |
-          ./gradlew stageJars
+          ./gradlew runtimeImage:stageJars
           ls -la runtimeImage/gretl/__jars4image
 
-      # - name: Debug1
-      #   run: |
-      #     ls -la ~/.m2/repository/ch/so/agi/gretl
-
-      - name: Set up QEMU for amd64 and arm64
-        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480  # v1.2.0 (2021-10-22)
-        with:
-          platforms: linux/amd64,linux/arm64
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25  # v1.6.0 (2021-10-22)
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@3a3bb3a81753dc99f090d24ee7e5343838b73a96  # v3.5.0 (2021-10-22)
-        with:
-          images: sogis/gretl
-          labels: |
-            org.opencontainers.image.title=gretl
-            org.opencontainers.image.version=3.0.${{ github.run_number }}
-            org.opencontainers.image.base.name=docker.io/eclipse-temurin:11-jdk-alpine
-          tags: |
-            type=raw,value=3.0.${{ github.run_number }},enable=true,priority=200
-            type=raw,value=3.0,enable=true,priority=200
-            type=raw,value=3,enable=true,priority=200
-            type=raw,value=latest,enable=true,priority=200
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9  # v1.10.0 (2021-10-22)
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-        if: ${{ (github.ref == 'refs/heads/master') && (github.event_name != 'pull_request') && !env.ACT }}
-
-      - name: Single-platform build 
-        uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229  # v2.7.0 (2021-10-22)
-        with:
-          platforms: linux/amd64
-          context: ./runtimeImage/gretl
-          file: ./runtimeImage/gretl/Dockerfile
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          load: true
-          pull: true 
+      - name: Build Docker image for integration tests
+        run: |
+          ./gradlew runtimeImage:buildImage
 
       - name: List images
         run: |
           docker images
 
-      - name: Integration Test (Docker Image)
-        run: |
-          TZ="Europe/Zurich" ./gradlew gretl:imageTest 
-          ./gradlew gretl:imageS3Test -Ds3AccessKey=$S3_ACCESS_KEY -Ds3SecretKey=$S3_SECRET_KEY -Ds3BucketName=ch.so.agi.gretl.test
-        env:
-          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
-          S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+      # - name: Debug1
+      #   run: |
+      #     ls -la ~/.m2/repository/ch/so/agi/gretl
+
+      # - name: Set up QEMU for amd64 and arm64
+      #   uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480  # v1.2.0 (2021-10-22)
+      #   with:
+      #     platforms: linux/amd64,linux/arm64
+
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25  # v1.6.0 (2021-10-22)
+
+      # - name: Docker meta
+      #   id: meta
+      #   uses: docker/metadata-action@3a3bb3a81753dc99f090d24ee7e5343838b73a96  # v3.5.0 (2021-10-22)
+      #   with:
+      #     images: sogis/gretl
+      #     labels: |
+      #       org.opencontainers.image.title=gretl
+      #       org.opencontainers.image.version=3.0.${{ github.run_number }}
+      #       org.opencontainers.image.base.name=docker.io/eclipse-temurin:11-jdk-alpine
+      #     tags: |
+      #       type=raw,value=3.0.${{ github.run_number }},enable=true,priority=200
+      #       type=raw,value=3.0,enable=true,priority=200
+      #       type=raw,value=3,enable=true,priority=200
+      #       type=raw,value=latest,enable=true,priority=200
+
+      # - name: Login to GitHub Container Registry
+      #   uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9  # v1.10.0 (2021-10-22)
+      #   with:
+      #     username: ${{ secrets.DOCKER_HUB_USERNAME }}
+      #     password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      #   if: ${{ (github.ref == 'refs/heads/master') && (github.event_name != 'pull_request') && !env.ACT }}
+
+      # - name: Single-platform build 
+      #   uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229  # v2.7.0 (2021-10-22)
+      #   with:
+      #     platforms: linux/amd64
+      #     context: ./runtimeImage/gretl
+      #     file: ./runtimeImage/gretl/Dockerfile
+      #     tags: ${{ steps.meta.outputs.tags }}
+      #     labels: ${{ steps.meta.outputs.labels }}
+      #     load: true
+      #     pull: true 
+
+
+      # - name: Integration Test (Docker Image)
+      #   run: |
+      #     TZ="Europe/Zurich" ./gradlew gretl:imageTest 
+      #     ./gradlew gretl:imageS3Test -Ds3AccessKey=$S3_ACCESS_KEY -Ds3SecretKey=$S3_SECRET_KEY -Ds3BucketName=ch.so.agi.gretl.test
+      #   env:
+      #     S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+      #     S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
       
-      - uses: actions/upload-artifact@v3
-        if: ${{ failure() }}
-        with:
-          name: reports-docker
-          path: |
-            gretl/build/reports/tests/
+      # - uses: actions/upload-artifact@v3
+      #   if: ${{ failure() }}
+      #   with:
+      #     name: reports-docker
+      #     path: |
+      #       gretl/build/reports/tests/
 
-      - name: Publish plugin
-        run: ./gradlew gretl:publishPlugins -s
-        if: ${{ (github.ref == 'refs/heads/master') && (github.event_name != 'pull_request') && !env.ACT }}
-        env:
-          gradlePublishKey: ${{ secrets.GRADLEPUBLISHKEY }}
-          gradlePublishSecret: ${{ secrets.GRADLEPUBLISHSECRET }}
+      # - name: Publish plugin
+      #   run: ./gradlew gretl:publishPlugins -s
+      #   if: ${{ (github.ref == 'refs/heads/master') && (github.event_name != 'pull_request') && !env.ACT }}
+      #   env:
+      #     gradlePublishKey: ${{ secrets.GRADLEPUBLISHKEY }}
+      #     gradlePublishSecret: ${{ secrets.GRADLEPUBLISHSECRET }}
 
-      - name: Multi-platform build 
-        uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229  # v2.7.0 (2021-10-22)
-        with:
-          platforms: linux/amd64,linux/arm64
-          context: ./runtimeImage/gretl
-          file: ./runtimeImage/gretl/Dockerfile
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          pull: true
-          push: ${{ (github.ref == 'refs/heads/master') && (github.event_name != 'pull_request') && !env.ACT }}
+      # - name: Multi-platform build 
+      #   uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229  # v2.7.0 (2021-10-22)
+      #   with:
+      #     platforms: linux/amd64,linux/arm64
+      #     context: ./runtimeImage/gretl
+      #     file: ./runtimeImage/gretl/Dockerfile
+      #     tags: ${{ steps.meta.outputs.tags }}
+      #     labels: ${{ steps.meta.outputs.labels }}
+      #     pull: true
+      #     push: ${{ (github.ref == 'refs/heads/master') && (github.event_name != 'pull_request') && !env.ACT }}

--- a/build.gradle
+++ b/build.gradle
@@ -13,10 +13,6 @@ allprojects {
         maven {
             url "https://plugins.gradle.org/m2/" 
             content {
-                // Damit wird sichergestellt, dass nicht die 2.9999-Releases
-                // vom Plugin-Portal verwendet werden.
-                // Schöner wäre, wenn man beim mavenLocal ein include...
-                // machen würde. Da verstehe ich aber die Syntax nicht.
                 excludeModule("ch.so.agi","gretl")            
             }
         } 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,6 @@
 [versions]
+ili2cCoreVersion = "5.3.2"
+ili2cToolVersion = "5.3.2"
 ioxIliVersion = "1.21.18"
 ilivalidatorVersion = "1.13.3"
 ilivalidatorCustomFunctionsVersion = "1.1.50"
@@ -42,6 +44,8 @@ cyclonedxBomVersion = "1.7.4"
 awsSdkV1Version = "1.12.761"
 
 [libraries]
+ili2c-core = { group = "ch.interlis", name = "ili2c-core", version.ref = "ili2cCoreVersion" }
+ili2c-tool = { group = "ch.interlis", name = "ili2c-tool", version.ref = "ili2cToolVersion" }
 iox-ili = { group = "ch.interlis", name = "iox-ili", version.ref = "ioxIliVersion" }
 ilivalidator = { group = "ch.interlis", name = "ilivalidator", version.ref = "ilivalidatorVersion" }
 ilivalidator-custom-functions = { group = "io.github.sogis", name = "ilivalidator-custom-functions", version.ref = "ilivalidatorCustomFunctionsVersion" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -78,10 +78,10 @@ junitTestContainers = { group = "org.testcontainers", name = "junit-jupiter", ve
 junitTestContainersPostgres = { group = "org.testcontainers", name = "postgresql", version.ref = "junitTestContainersVersion" }
 mock-ftp-server = { group = "org.mockftpserver", name = "MockFtpServer", version.ref = "mockFtpServerVersion" }
 mock-web-server = { group = "com.squareup.okhttp3", name ="mockwebserver", version.ref = "mockWebServerVersion"}
-test-containers-base = { group = "org.testcontainers", name = "testcontainers", version.ref = "testContainersVersion"}
-test-containers-postgresql = { group = "org.testcontainers", name = "postgresql", version.ref = "testContainersVersion"}
-test-containers-oracle = { group = "org.testcontainers", name = "oracle-xe", version.ref = "testContainersVersion"}
-test-containers-localstack = { group = "org.testcontainers", name = "localstack", version.ref = "testContainersVersion" }
+testcontainers-base = { group = "org.testcontainers", name = "testcontainers", version.ref = "testContainersVersion"}
+testcontainers-postgresql = { group = "org.testcontainers", name = "postgresql", version.ref = "testContainersVersion"}
+testcontainers-oracle = { group = "org.testcontainers", name = "oracle-xe", version.ref = "testContainersVersion"}
+testcontainers-localstack = { group = "org.testcontainers", name = "localstack", version.ref = "testContainersVersion" }
 sftp-fs = { group = "com.github.robtimus", name = "sftp-fs", version.ref = "sftpFsVersion"}
 tomcat-embed-core = { group = "org.apache.tomcat.embed", name = "tomcat-embed-core", version.ref = "tomcatEmbedVersion" }
 hadoop-client = { group = "org.apache.hadoop", name = "hadoop-client", version.ref = "hadoopClientVersion" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,9 +35,8 @@ testContainersVersion = "1.15.3"
 sftpFsVersion = "2.0.4"
 tomcatEmbedVersion = "9.0.69"
 hadoopClientVersion = "3.3.5"
-gradleDownloadTaskVersion = "4.1.2"
+gradleDownloadTaskPluginVersion = "4.1.2"
 gradleSshPluginVersion = "2.9.0"
-gradleAwsPluginVersion = "0.41"
 pluginPublishVersion = "0.21.0"
 cyclonedxBomVersion = "1.7.4"
 awsSdkV1Version = "1.12.761"
@@ -86,9 +85,8 @@ test-containers-localstack = { group = "org.testcontainers", name = "localstack"
 sftp-fs = { group = "com.github.robtimus", name = "sftp-fs", version.ref = "sftpFsVersion"}
 tomcat-embed-core = { group = "org.apache.tomcat.embed", name = "tomcat-embed-core", version.ref = "tomcatEmbedVersion" }
 hadoop-client = { group = "org.apache.hadoop", name = "hadoop-client", version.ref = "hadoopClientVersion" }
-gradle-download-task = {group = "de.undercouch", name = "gradle-download-task", version.ref = "gradleDownloadTaskVersion"}
+gradle-download-task-plugin = {group = "de.undercouch", name = "gradle-download-task", version.ref = "gradleDownloadTaskPluginVersion"}
 gradle-ssh-plugin = {group = "org.hidetake", name = "gradle-ssh-plugin", version.ref = "gradleSshPluginVersion"}
-gradle-aws-plugin = {group = "jp.classmethod.aws", name = "gradle-aws-plugin", version.ref = "gradleAwsPluginVersion"}
 
 [plugins]
 plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "pluginPublishVersion" }

--- a/gretl/build.gradle
+++ b/gretl/build.gradle
@@ -28,8 +28,8 @@ configurations.all {
 
 configurations.all {
     resolutionStrategy { 
-        force 'ch.interlis:ili2c-tool:5.3.2' 
-        force 'ch.interlis:ili2c-core:5.3.2'
+        force libs.ili2c.core
+        force libs.ili2c.tool
         force libs.ili2gpkg
         force libs.iox.ili
     }

--- a/gretl/build.gradle
+++ b/gretl/build.gradle
@@ -30,8 +30,8 @@ configurations.all {
     resolutionStrategy { 
         force 'ch.interlis:ili2c-tool:5.3.2' 
         force 'ch.interlis:ili2c-core:5.3.2'
-        force 'ch.interlis:ili2gpkg:4.11.1'
-        force 'ch.interlis:iox-ili:1.21.18'
+        force libs.ili2gpkg
+        force libs.iox.ili
     }
 }
 
@@ -120,10 +120,10 @@ dependencies {
     testImplementation libs.junitTestContainersPostgres
     testRuntimeOnly libs.junitEngine
 
-    testImplementation libs.test.containers.base
-    testImplementation libs.test.containers.postgresql
-    testImplementation libs.test.containers.oracle
-    testImplementation libs.test.containers.localstack
+    testImplementation libs.testcontainers.base
+    testImplementation libs.testcontainers.postgresql
+    testImplementation libs.testcontainers.oracle
+    testImplementation libs.testcontainers.localstack
     /*
         Version 1 des SDK wird wegen Testcontainers benoetigt:
         - https://stackoverflow.com/questions/29024520/classnotfoundexception-com-amazonaws-auth-awscredentials-java

--- a/runtimeImage/build.gradle
+++ b/runtimeImage/build.gradle
@@ -13,9 +13,8 @@ dependencies {
     api 'ch.so.agi:gretl:3.0.+'
 
     // Add 3rd party libs which we want in the docker image.
-    api libs.gradle.download.task
+    api libs.gradle.download.task.plugin
     api libs.gradle.ssh.plugin
-    api libs.gradle.aws.plugin
 }
 
 task stageJars(type: Copy) {

--- a/runtimeImage/build.gradle
+++ b/runtimeImage/build.gradle
@@ -38,6 +38,26 @@ tasks.register('buildImage', Exec) {
                 '-f', 'Dockerfile',  '.'
 }
 
+// Zum Publizieren der Images
+tasks.register('buildAndPushMultiArchImage', Exec) {
+    dependsOn 'stageJars'
+    description = 'Build final multi-arch Docker image.'
+    def githash = getCheckedOutGitCommitHash()
+    def build_timestamp = getTimestamp()
+
+    workingDir "$projectDir/gretl"
+    commandLine 'docker', 'buildx', 'build',
+                '--platform', 'linux/amd64,linux/arm64',
+                '-t', "sogis/gretl:$version.major",
+                '-t', "sogis/gretl:$version.major.$version.minor",
+                '-t', "sogis/gretl:$version.major.$version.minor.$version.build",
+                '-t', "sogis/gretl:latest",
+                '--label', "gretl.created=$build_timestamp", 
+                '--label', "gretl.git_commit=$githash",
+                '--label', "gretl.version=$version",
+                //'-f', 'Dockerfile',  '.', '--push'
+                '-f', 'Dockerfile',  '.'
+}
 
 def getCheckedOutGitCommitHash() {
     'git log -1 --pretty=%H'.execute().text.trim()

--- a/runtimeImage/build.gradle
+++ b/runtimeImage/build.gradle
@@ -4,8 +4,8 @@ configurations.all {
     resolutionStrategy { 
         force 'ch.interlis:ili2c-tool:5.3.2' 
         force 'ch.interlis:ili2c-core:5.3.2'
-        force 'ch.interlis:ili2gpkg:4.11.1'
-        force 'ch.interlis:iox-ili:1.21.18'
+        force libs.ili2gpkg
+        force libs.iox.ili
     }
 }
 

--- a/runtimeImage/build.gradle
+++ b/runtimeImage/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java-library'
 
 configurations.all {
     resolutionStrategy { 
-        force 'ch.interlis:ili2c-tool:5.3.2' 
-        force 'ch.interlis:ili2c-core:5.3.2'
+        force libs.ili2c.core
+        force libs.ili2c.tool
         force libs.ili2gpkg
         force libs.iox.ili
     }
@@ -17,9 +17,33 @@ dependencies {
     api libs.gradle.ssh.plugin
 }
 
-task stageJars(type: Copy) {
+tasks.register('stageJars', Copy) {
     description = 'Copies all jars required by gretl to the temp folder __jars4image.'
     from configurations.compileClasspath
     from configurations.runtimeClasspath
     into "gretl/__jars4image"
+}
+
+// Zum Testen des Images mit den Integrationstest
+tasks.register('buildImage', Exec) {
+    dependsOn 'stageJars'
+    description = 'Build Docker image for unit tests.'
+    def githash = getCheckedOutGitCommitHash()
+    def build_timestamp = getTimestamp()
+
+    workingDir "$projectDir/gretl"
+    commandLine 'docker', 'build',
+                '--no-cache', '--force-rm',
+                '-t', "sogis/gretl:latest",
+                '-f', 'Dockerfile',  '.'
+}
+
+
+def getCheckedOutGitCommitHash() {
+    'git log -1 --pretty=%H'.execute().text.trim()
+}
+
+def getTimestamp() {
+    def date = new Date()
+    return date.format('yyyy-MM-dd HH:mm:ss')
 }


### PR DESCRIPTION
So können Images einfacher lokal erstellt werden. Login und Buildx Preparation wird weiterhin in GH Action gemacht.