### PR TITLE
Don't globally disable daemon

### DIFF
--- a/runtimeImage/gretl/gretl
+++ b/runtimeImage/gretl/gretl
@@ -8,4 +8,4 @@ fi
 
 gradle $run_parameter \
        --init-script /home/gradle/init.gradle \
-       --no-daemon -s
+       -s

--- a/runtimeImage/gretl/gretl
+++ b/runtimeImage/gretl/gretl
@@ -7,5 +7,4 @@ if [ -f /home/gradle/build.info ]; then
 fi
 
 gradle $run_parameter \
-       --init-script /home/gradle/init.gradle \
-       -s
+       --init-script /home/gradle/init.gradle


### PR DESCRIPTION
* Don't globally disable daemon in the Docker image.
* Don't globally enable printing the stacktrace in the Docker image.

Rather add these options to the individual commands where necessary.

https://sogis.openproject.com/projects/gretl/work_packages/2940